### PR TITLE
The Copper Age + Mounts of Mayhem

### DIFF
--- a/MobHeads-master/MobHeads.iml
+++ b/MobHeads-master/MobHeads.iml
@@ -21,7 +21,7 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.spigotmc:spigot-api:1.21.8-R0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.spigotmc:spigot-api:1.21.9-R0.1-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.guava:guava:31.0.1-jre" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.guava:failureaccess:1.0.1" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava" level="project" />

--- a/MobHeads-master/plugin.yml
+++ b/MobHeads-master/plugin.yml
@@ -1,11 +1,11 @@
 name: MobHeads
 main: com.cyber.mobheads.Main
-version: 4.0
+version: 5.0
 authors:
     - CyberDrain
     - Zombie_Striker
     - Lord_Lofi
-api-version: 1.19
+api-version: 1.21.9
 description: Allows players to behead mobs and other players!
 commands:
     mobheads:

--- a/MobHeads-master/pom.xml
+++ b/MobHeads-master/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.21.8-R0.1-SNAPSHOT</version>
+            <version>1.21.9-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- WorldGuard API -->

--- a/README.md
+++ b/README.md
@@ -250,6 +250,12 @@ Panda_Weak,
 Fox_Normal,
 Fox_Snow,
 
+----copper golem types----
+Copper_Golem,
+Exposed_Copper_Golem,
+Oxidized_Copper_Golem,
+Weathered_Copper_Golem,
+
 ----cat types----
 Cat_AllBack,
 Cat_Black,

--- a/achievements/achievements/data/mobheads/advancement/arthropods.json
+++ b/achievements/achievements/data/mobheads/advancement/arthropods.json
@@ -1,0 +1,46 @@
+{
+  "display": {
+    "description": {
+      "text": "Obtain all arthropod mob heads",
+      "color": "white"
+    },
+    "title": {
+      "text": "Eight Legs Too Many",
+      "color": "dark_gray"
+    },
+    "icon": {
+      "id": "spider_eye"
+    },
+    "frame": "challenge"
+  },
+  "criteria": {
+    "spider": {
+      "trigger": "minecraft:impossible"
+    },
+    "cave_spider": {
+      "trigger": "minecraft:impossible"
+    },
+    "silverfish": {
+      "trigger": "minecraft:impossible"
+    },
+    "bee": {
+      "trigger": "minecraft:impossible"
+    }
+  },
+  "rewards": {},
+  "requirements": [
+    [
+      "spider"
+    ],
+    [
+      "cave_spider"
+    ],
+    [
+      "silverfish"
+    ],
+    [
+      "bee"
+    ]
+  ],
+  "parent": "mobheads:firstmobhead"
+}

--- a/achievements/achievements/data/mobheads/advancement/axolotl.json
+++ b/achievements/achievements/data/mobheads/advancement/axolotl.json
@@ -9,8 +9,7 @@
 			"color": "white"
 		},
 		"icon": {
-			"id": "axolotl_bucket",
-			"tag": 0
+			"id": "axolotl_bucket"
 		},
 		"frame": "challenge"
 	},
@@ -39,8 +38,5 @@
 		["Lucy_Axolotl"],
 		["Wild_Axolotl"]
 	],
-	"filename": 24,
-	"parent-count": 3,
-	"parent-type": "parent",
 	"parent": "mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/cat.json
+++ b/achievements/achievements/data/mobheads/advancement/cat.json
@@ -9,8 +9,7 @@
          "color":"white"
       },
       "icon":{
-         "id":"salmon",
-		 "tag":0
+         "id":"salmon"
       },
       "frame":"challenge"
    },
@@ -93,8 +92,5 @@
          "ocelot"
       ]
    ],
-   "filename":16,
-   "parent-count":3,
-   "parent-type":"parent",
    "parent":"mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/cold_biome.json
+++ b/achievements/achievements/data/mobheads/advancement/cold_biome.json
@@ -1,0 +1,46 @@
+{
+  "display": {
+    "description": {
+      "text": "Obtain all cold biome mob heads",
+      "color": "white"
+    },
+    "title": {
+      "text": "It's Freezing Out Here",
+      "color": "aqua"
+    },
+    "icon": {
+      "id": "snowball"
+    },
+    "frame": "challenge"
+  },
+  "criteria": {
+    "stray": {
+      "trigger": "minecraft:impossible"
+    },
+    "polar_bear": {
+      "trigger": "minecraft:impossible"
+    },
+    "snow_golem": {
+      "trigger": "minecraft:impossible"
+    },
+    "derpy_snow_golem": {
+      "trigger": "minecraft:impossible"
+    }
+  },
+  "rewards": {},
+  "requirements": [
+    [
+      "stray"
+    ],
+    [
+      "polar_bear"
+    ],
+    [
+      "snow_golem"
+    ],
+    [
+      "derpy_snow_golem"
+    ]
+  ],
+  "parent": "mobheads:firstmobhead"
+}

--- a/achievements/achievements/data/mobheads/advancement/copperage.json
+++ b/achievements/achievements/data/mobheads/advancement/copperage.json
@@ -1,0 +1,52 @@
+{
+  "display":{
+    "description":{
+      "text":"Obtain all copper golem mob heads",
+      "color":"white"
+    },
+    "title":{
+      "text":"The Copper Age!",
+      "color":"dark_aqua"
+    },
+    "icon":{
+      "id":"minecraft:copper_golem_spawn_egg",
+      "tag":0
+    },
+    "frame":"challenge"
+  },
+  "criteria":{
+    "copper_golem":{
+      "trigger":"minecraft:impossible"
+    },
+    "exposed_copper_golem":{
+      "trigger":"minecraft:impossible"
+    },
+    "weathered_copper_golem":{
+      "trigger":"minecraft:impossible"
+    },
+    "oxidized_copper_golem":{
+      "trigger":"minecraft:impossible"
+    }
+  },
+  "rewards":{
+
+  },
+  "requirements":[
+    [
+      "copper_golem"
+    ],
+    [
+      "exposed_copper_golem"
+    ],
+    [
+      "weathered_copper_golem"
+    ],
+    [
+      "oxidized_copper_golem"
+    ]
+  ],
+  "filename":35,
+  "parent-count":3,
+  "parent-type":"parent",
+  "parent":"mobheads:firstmobhead"
+}

--- a/achievements/achievements/data/mobheads/advancement/copperage.json
+++ b/achievements/achievements/data/mobheads/advancement/copperage.json
@@ -9,8 +9,7 @@
       "color":"dark_aqua"
     },
     "icon":{
-      "id":"minecraft:copper_golem_spawn_egg",
-      "tag":0
+      "id":"minecraft:copper_golem_spawn_egg"
     },
     "frame":"challenge"
   },
@@ -45,8 +44,5 @@
       "oxidized_copper_golem"
     ]
   ],
-  "filename":35,
-  "parent-count":3,
-  "parent-type":"parent",
   "parent":"mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/creaking.json
+++ b/achievements/achievements/data/mobheads/advancement/creaking.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "creaking_heart",
-      "tag": 0
+      "id": "creaking_heart"
     },
     "frame": "challenge"
   },
@@ -26,8 +25,5 @@
       "creaking"
     ]
   ],
-  "filename": 250,
-  "parent-count": 3,
-  "parent-type": "parent",
   "parent": "mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/deep_dark.json
+++ b/achievements/achievements/data/mobheads/advancement/deep_dark.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "sculk_shrieker",
-      "tag": 0
+      "id": "sculk_shrieker"
     },
     "frame": "challenge"
   },
@@ -26,8 +25,5 @@
       "warden"
     ]
   ],
-  "filename": 25,
-  "parent-count": 3,
-  "parent-type": "parent",
   "parent": "mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/desert.json
+++ b/achievements/achievements/data/mobheads/advancement/desert.json
@@ -25,6 +25,12 @@
     },
     "scared_armadillo": {
       "trigger": "minecraft:impossible"
+    },
+    "parched": {
+      "trigger": "minecraft:impossible"
+    },
+    "camel_husk": {
+      "trigger": "minecraft:impossible"
     }
   },
   "rewards": {},
@@ -40,6 +46,12 @@
     ],
     [
       "scared_armadillo"
+    ],
+    [
+      "parched"
+    ],
+    [
+      "camel_husk"
     ]
   ],
   "parent": "mobheads:firstmobhead"

--- a/achievements/achievements/data/mobheads/advancement/desert.json
+++ b/achievements/achievements/data/mobheads/advancement/desert.json
@@ -1,0 +1,46 @@
+{
+  "display": {
+    "description": {
+      "text": "Obtain all desert mob heads",
+      "color": "white"
+    },
+    "title": {
+      "text": "Sand in Your Head",
+      "color": "yellow"
+    },
+    "icon": {
+      "id": "cactus"
+    },
+    "frame": "challenge"
+  },
+  "criteria": {
+    "husk": {
+      "trigger": "minecraft:impossible"
+    },
+    "camel": {
+      "trigger": "minecraft:impossible"
+    },
+    "armadillo": {
+      "trigger": "minecraft:impossible"
+    },
+    "scared_armadillo": {
+      "trigger": "minecraft:impossible"
+    }
+  },
+  "rewards": {},
+  "requirements": [
+    [
+      "husk"
+    ],
+    [
+      "camel"
+    ],
+    [
+      "armadillo"
+    ],
+    [
+      "scared_armadillo"
+    ]
+  ],
+  "parent": "mobheads:firstmobhead"
+}

--- a/achievements/achievements/data/mobheads/advancement/end_dimension.json
+++ b/achievements/achievements/data/mobheads/advancement/end_dimension.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "end_stone",
-      "tag": 0
+      "id": "end_stone"
     },
     "frame": "challenge"
   },
@@ -43,8 +42,5 @@
       "shulker"
     ]
   ],
-  "filename": 9,
-  "parent-count": 3,
-  "parent-type": "parent",
   "parent": "mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/firstmobhead.json
+++ b/achievements/achievements/data/mobheads/advancement/firstmobhead.json
@@ -9,8 +9,7 @@
          "color":"white"
       },
       "icon":{
-         "id":"creeper_head",
-         "tag":0
+         "id":"creeper_head"
       }
    },
    "criteria":{

--- a/achievements/achievements/data/mobheads/advancement/fish.json
+++ b/achievements/achievements/data/mobheads/advancement/fish.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "tropical_fish",
-      "tag": 0
+      "id": "tropical_fish"
     },
     "frame": "challenge"
   },
@@ -43,8 +42,5 @@
       "salmon"
     ]
   ],
-  "filename": 19,
-  "parent-count": 3,
-  "parent-type": "parent",
   "parent": "mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/goat.json
+++ b/achievements/achievements/data/mobheads/advancement/goat.json
@@ -9,8 +9,7 @@
 			"color": "white"
 		},
 		"icon": {
-			"id": "goat_horn",
-			"tag": 0
+			"id": "goat_horn"
 		},
 		"frame": "challenge"
 	},
@@ -27,8 +26,5 @@
 		["goat"],
 		["screaming_goat"]
 	],
-	"filename": 23,
-	"parent-count": 3,
-	"parent-type": "parent",
 	"parent": "mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/goat.json
+++ b/achievements/achievements/data/mobheads/advancement/goat.json
@@ -15,17 +15,17 @@
 		"frame": "challenge"
 	},
 	"criteria": {
-		"goat_head1": {
+		"goat": {
 			"trigger": "minecraft:impossible"
 		},
-		"screaming_goat_head1": {
+		"screaming_goat": {
 			"trigger": "minecraft:impossible"
 		}
 	},
 	"rewards": {},
 	"requirements": [
-		["goat_head1"],
-		["screaming_goat_head1"]
+		["goat"],
+		["screaming_goat"]
 	],
 	"filename": 23,
 	"parent-count": 3,

--- a/achievements/achievements/data/mobheads/advancement/golem.json
+++ b/achievements/achievements/data/mobheads/advancement/golem.json
@@ -1,0 +1,46 @@
+{
+  "display":{
+    "description":{
+      "text":"Obtain all golem mob heads",
+      "color":"white"
+    },
+    "title":{
+      "text":"The Golem Rule!",
+      "color":"gold"
+    },
+    "icon":{
+      "id":"carved_pumpkin",
+      "tag":0
+    },
+    "frame":"challenge"
+  },
+  "criteria":{
+    "snow_golem":{
+      "trigger":"minecraft:impossible"
+    },
+    "iron_golem":{
+      "trigger":"minecraft:impossible"
+    },
+    "copper_golem":{
+      "trigger":"minecraft:impossible"
+    }
+  },
+  "rewards":{
+
+  },
+  "requirements":[
+    [
+      "snow_golem"
+    ],
+    [
+      "iron_golem"
+    ],
+    [
+      "copper_golem"
+    ]
+  ],
+  "filename":35,
+  "parent-count":3,
+  "parent-type":"parent",
+  "parent":"mobheads:firstmobhead"
+}

--- a/achievements/achievements/data/mobheads/advancement/golem.json
+++ b/achievements/achievements/data/mobheads/advancement/golem.json
@@ -22,6 +22,9 @@
     },
     "copper_golem":{
       "trigger":"minecraft:impossible"
+    },
+    "derpy_snow_golem":{
+      "trigger":"minecraft:impossible"
     }
   },
   "rewards":{
@@ -36,6 +39,9 @@
     ],
     [
       "copper_golem"
+    ],
+    [
+      "derpy_snow_golem"
     ]
   ],
   "parent":"mobheads:firstmobhead"

--- a/achievements/achievements/data/mobheads/advancement/golem.json
+++ b/achievements/achievements/data/mobheads/advancement/golem.json
@@ -9,8 +9,7 @@
       "color":"gold"
     },
     "icon":{
-      "id":"carved_pumpkin",
-      "tag":0
+      "id":"carved_pumpkin"
     },
     "frame":"challenge"
   },
@@ -39,8 +38,5 @@
       "copper_golem"
     ]
   ],
-  "filename":35,
-  "parent-count":3,
-  "parent-type":"parent",
   "parent":"mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/happyghast.json
+++ b/achievements/achievements/data/mobheads/advancement/happyghast.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "ghast_tear",
-      "tag": 0
+      "id": "ghast_tear"
     },
     "frame": "challenge"
   },

--- a/achievements/achievements/data/mobheads/advancement/horse.json
+++ b/achievements/achievements/data/mobheads/advancement/horse.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "saddle",
-      "tag": 0
+      "id": "saddle"
     },
     "frame": "challenge"
   },
@@ -67,8 +66,5 @@
       "black_horse"
     ]
   ],
-  "filename": 12,
-  "parent-count": 3,
-  "parent-type": "parent",
   "parent": "mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/illusioner.json
+++ b/achievements/achievements/data/mobheads/advancement/illusioner.json
@@ -9,8 +9,7 @@
          "color":"white"
       },
       "icon":{
-         "id":"bow",
-         "tag":0
+         "id":"bow"
       },
       "frame":"goal",
 	  "hidden":true
@@ -28,8 +27,5 @@
          "illusioner"
       ]
    ],
-   "filename":22,
-   "parent-count":16,
-   "parent-type":"child",
    "parent":"mobheads:woodland_mansion"
 }

--- a/achievements/achievements/data/mobheads/advancement/llama.json
+++ b/achievements/achievements/data/mobheads/advancement/llama.json
@@ -26,14 +26,30 @@
 		},
 		"brown_llama": {
 			"trigger": "minecraft:impossible"
-		}
+		},
+        "white_llama_trader": {
+          "trigger": "minecraft:impossible"
+        },
+        "gray_llama_trader": {
+          "trigger": "minecraft:impossible"
+        },
+        "creamy_llama_trader": {
+          "trigger": "minecraft:impossible"
+        },
+        "brown_llama_trader": {
+          "trigger": "minecraft:impossible"
+        }
 	},
 	"rewards": {},
 	"requirements": [
 		["white_llama"],
 		["gray_llama"],
 		["creamy_llama"],
-		["brown_llama"]
+		["brown_llama"],
+        ["white_llama_trader"],
+        ["gray_llama_trader"],
+        ["creamy_llama_trader"],
+        ["brown_llama_trader"]
 	],
 	"filename": 13,
 	"parent-count": 3,

--- a/achievements/achievements/data/mobheads/advancement/llama.json
+++ b/achievements/achievements/data/mobheads/advancement/llama.json
@@ -9,8 +9,7 @@
 			"color": "white"
 		},
 		"icon": {
-			"id": "water_bucket",
-			"tag": 0
+			"id": "water_bucket"
 		},
 		"frame": "challenge"
 	},
@@ -51,8 +50,5 @@
         ["creamy_llama_trader"],
         ["brown_llama_trader"]
 	],
-	"filename": 13,
-	"parent-count": 3,
-	"parent-type": "parent",
 	"parent": "mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/mushroom.json
+++ b/achievements/achievements/data/mobheads/advancement/mushroom.json
@@ -1,0 +1,34 @@
+{
+  "display": {
+    "description": {
+      "text": "Obtain all mushroom island mob heads",
+      "color": "white"
+    },
+    "title": {
+      "text": "Fun-gus Among Us",
+      "color": "dark_red"
+    },
+    "icon": {
+      "id": "red_mushroom"
+    },
+    "frame": "challenge"
+  },
+  "criteria": {
+    "mooshroom": {
+      "trigger": "minecraft:impossible"
+    },
+    "mooshroom_brown": {
+      "trigger": "minecraft:impossible"
+    }
+  },
+  "rewards": {},
+  "requirements": [
+    [
+      "mooshroom"
+    ],
+    [
+      "mooshroom_brown"
+    ]
+  ],
+  "parent": "mobheads:firstmobhead"
+}

--- a/achievements/achievements/data/mobheads/advancement/nautilus.json
+++ b/achievements/achievements/data/mobheads/advancement/nautilus.json
@@ -1,0 +1,40 @@
+{
+  "display": {
+    "description": {
+      "text": "Obtain all nautilus heads",
+      "color": "white"
+    },
+    "title": {
+      "text": "Shell Shocked",
+      "color": "aqua"
+    },
+    "icon": {
+      "id": "nautilus_shell"
+    },
+    "frame": "challenge"
+  },
+  "criteria": {
+    "nautilus": {
+      "trigger": "minecraft:impossible"
+    },
+    "temperate_zombie_nautilus": {
+      "trigger": "minecraft:impossible"
+    },
+    "warm_zombie_nautilus": {
+      "trigger": "minecraft:impossible"
+    }
+  },
+  "rewards": {},
+  "requirements": [
+    [
+      "nautilus"
+    ],
+    [
+      "temperate_zombie_nautilus"
+    ],
+    [
+      "warm_zombie_nautilus"
+    ]
+  ],
+  "parent": "mobheads:firstmobhead"
+}

--- a/achievements/achievements/data/mobheads/advancement/nether_dimension.json
+++ b/achievements/achievements/data/mobheads/advancement/nether_dimension.json
@@ -43,6 +43,9 @@
     },
     "magma_cube": {
       "trigger": "minecraft:impossible"
+    },
+    "wither_skeleton": {
+      "trigger": "minecraft:impossible"
     }
   },
   "rewards": {},
@@ -76,6 +79,9 @@
     ],
     [
       "magma_cube"
+    ],
+    [
+      "wither_skeleton"
     ]
   ],
   "parent": "mobheads:firstmobhead"

--- a/achievements/achievements/data/mobheads/advancement/nether_dimension.json
+++ b/achievements/achievements/data/mobheads/advancement/nether_dimension.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "magma_cream",
-      "tag": 0
+      "id": "magma_cream"
     },
     "frame": "challenge"
   },
@@ -79,8 +78,5 @@
       "magma_cube"
     ]
   ],
-  "filename": 10,
-  "parent-count": 3,
-  "parent-type": "parent",
   "parent": "mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/night_mobs.json
+++ b/achievements/achievements/data/mobheads/advancement/night_mobs.json
@@ -1,63 +1,57 @@
 {
   "display": {
     "description": {
-      "text": "Obtain all panda heads",
+      "text": "Obtain all common night mob heads",
       "color": "white"
     },
     "title": {
-      "text": "Black, White, and Head all over",
-      "color": "white"
+      "text": "Things That Go Bump",
+      "color": "dark_purple"
     },
     "icon": {
-      "id": "bamboo"
+      "id": "rotten_flesh"
     },
     "frame": "challenge"
   },
   "criteria": {
-    "panda_aggressive": {
+    "zombie": {
       "trigger": "minecraft:impossible"
     },
-    "panda_brown": {
+    "skeleton": {
       "trigger": "minecraft:impossible"
     },
-    "panda_lazy": {
+    "creeper": {
       "trigger": "minecraft:impossible"
     },
-    "panda_normal": {
+    "charged_creeper": {
       "trigger": "minecraft:impossible"
     },
-    "panda_playful": {
+    "phantom": {
       "trigger": "minecraft:impossible"
     },
-    "panda_weak": {
-      "trigger": "minecraft:impossible"
-    },
-    "panda_worried": {
+    "bat": {
       "trigger": "minecraft:impossible"
     }
   },
   "rewards": {},
   "requirements": [
     [
-      "panda_aggressive"
+      "zombie"
     ],
     [
-      "panda_brown"
+      "skeleton"
     ],
     [
-      "panda_lazy"
+      "creeper"
     ],
     [
-      "panda_normal"
+      "charged_creeper"
     ],
     [
-      "panda_playful"
+      "phantom"
     ],
     [
-      "panda_weak"
-    ],
-    [
-      "panda_worried"
+      "bat"
     ]
   ],
   "parent": "mobheads:firstmobhead"

--- a/achievements/achievements/data/mobheads/advancement/ocean_monument.json
+++ b/achievements/achievements/data/mobheads/advancement/ocean_monument.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "prismarine",
-      "tag": 0
+      "id": "prismarine"
     },
     "frame": "challenge"
   },
@@ -31,8 +30,5 @@
       "elder_guardian"
     ]
   ],
-  "filename": 15,
-  "parent-count": 3,
-  "parent-type": "parent",
   "parent": "mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/panda.json
+++ b/achievements/achievements/data/mobheads/advancement/panda.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "item": "bamboo",
-      "tag": 0
+      "item": "bamboo"
     },
     "frame": "challenge"
   },
@@ -61,8 +60,5 @@
       "panda_worried"
     ]
   ],
-  "filename": 9,
-  "parent-count": 3,
-  "parent-type": "child",
   "parent": "mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/panda.json
+++ b/achievements/achievements/data/mobheads/advancement/panda.json
@@ -15,7 +15,7 @@
     "frame": "challenge"
   },
   "criteria": {
-    "panda_agressive": {
+    "panda_aggressive": {
       "trigger": "minecraft:impossible"
     },
     "panda_brown": {
@@ -40,7 +40,7 @@
   "rewards": {},
   "requirements": [
     [
-      "panda_agressive"
+      "panda_aggressive"
     ],
     [
       "panda_brown"

--- a/achievements/achievements/data/mobheads/advancement/parrot.json
+++ b/achievements/achievements/data/mobheads/advancement/parrot.json
@@ -9,8 +9,7 @@
          "color":"white"
       },
       "icon":{  
-         "id":"minecraft:beetroot_seeds",
-		 "tag":0
+         "id":"minecraft:beetroot_seeds"
       },
       "frame":"challenge"
    },
@@ -51,8 +50,5 @@
          "cyan_parrot"
       ]
    ],
-   "filename":14,
-   "parent-count":3,
-   "parent-type":"parent",
    "parent":"mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/player.json
+++ b/achievements/achievements/data/mobheads/advancement/player.json
@@ -24,6 +24,5 @@
       "first_player_head"
     ]
   ],
-  "parent": "mobheads:root",
-  "parent-type": "parent"
+  "parent": "mobheads:root"
 }

--- a/achievements/achievements/data/mobheads/advancement/player.json
+++ b/achievements/achievements/data/mobheads/advancement/player.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "player_head",
-      "tag": 0
+      "id": "player_head"
     },
     "frame": "task"
   },
@@ -26,7 +25,5 @@
     ]
   ],
   "parent": "mobheads:root",
-  "filename": 4,
-  "parent-count": 1,
   "parent-type": "parent"
 }

--- a/achievements/achievements/data/mobheads/advancement/rabbit.json
+++ b/achievements/achievements/data/mobheads/advancement/rabbit.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "carrot",
-      "tag": 0
+      "id": "carrot"
     },
     "frame": "challenge"
   },
@@ -61,8 +60,5 @@
       "white_rabbit"
     ]
   ],
-  "filename": 8,
-  "parent-count": 3,
-  "parent-type": "child",
   "parent": "mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/raid.json
+++ b/achievements/achievements/data/mobheads/advancement/raid.json
@@ -1,0 +1,34 @@
+{
+  "display": {
+    "description": {
+      "text": "Obtain all raid mob heads",
+      "color": "white"
+    },
+    "title": {
+      "text": "The Village Defenders",
+      "color": "red"
+    },
+    "icon": {
+      "id": "crossbow"
+    },
+    "frame": "challenge"
+  },
+  "criteria": {
+    "pillager": {
+      "trigger": "minecraft:impossible"
+    },
+    "ravager": {
+      "trigger": "minecraft:impossible"
+    }
+  },
+  "rewards": {},
+  "requirements": [
+    [
+      "pillager"
+    ],
+    [
+      "ravager"
+    ]
+  ],
+  "parent": "mobheads:firstmobhead"
+}

--- a/achievements/achievements/data/mobheads/advancement/root.json
+++ b/achievements/achievements/data/mobheads/advancement/root.json
@@ -3,7 +3,7 @@
 		"icon": {
 			"id": "minecraft:parrot_spawn_egg"
 		},
-		"title": "Mob Heads",
+		"title": {"text": "Mob Heads"},
 		"frame": "challenge",
 		"description": [
 			"",

--- a/achievements/achievements/data/mobheads/advancement/sheep.json
+++ b/achievements/achievements/data/mobheads/advancement/sheep.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "white_wool",
-      "tag": 0
+      "id": "white_wool"
     },
     "frame": "challenge"
   },
@@ -121,8 +120,5 @@
       "yellow_sheep"
     ]
   ],
-  "filename": 17,
-  "parent-count": 3,
-  "parent-type": "parent",
   "parent": "mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/swampmobs.json
+++ b/achievements/achievements/data/mobheads/advancement/swampmobs.json
@@ -15,22 +15,22 @@
       "frame":"challenge"
    },
    "criteria":{
-      "coldfroghead":{  
+      "cold_frog":{
          "trigger":"minecraft:impossible"
       },
-      "coldfroggy":{  
+      "cold_froggy":{
          "trigger":"minecraft:impossible"
       },
-      "warmfroghead":{  
+      "warm_frog":{
          "trigger":"minecraft:impossible"
       },
-      "warmfroggy":{  
+      "warm_froggy":{
          "trigger":"minecraft:impossible"
       },
-      "temperatefroghead":{  
+      "temperate_frog":{
          "trigger":"minecraft:impossible"
       },
-      "temperatefroggy":{  
+      "temperate_froggy":{
          "trigger":"minecraft:impossible"
       },
       "slime":{  
@@ -48,22 +48,22 @@
    },
    "requirements":[  
       [  
-         "coldfroghead"
+         "cold_frog"
       ],
       [  
-         "coldfroggy"
+         "cold_froggy"
       ],
       [ 
-         "warmfroghead"
+         "warm_frog"
       ],
       [  
-         "warmfroggy"
+         "warm_froggy"
       ],
       [  
-         "temperatefroghead"
+         "temperate_frog"
       ],
       [  
-         "temperatefroggy"
+         "temperate_froggy"
       ],
       [ 
          "slime"

--- a/achievements/achievements/data/mobheads/advancement/swampmobs.json
+++ b/achievements/achievements/data/mobheads/advancement/swampmobs.json
@@ -38,14 +38,17 @@
       "bogged":{  
          "trigger":"minecraft:impossible"
       },
-      "tadpole":{  
+      "tadpole":{
+         "trigger":"minecraft:impossible"
+      },
+      "witch":{
          "trigger":"minecraft:impossible"
       }
    },
-   "rewards":{  
+   "rewards":{
 
    },
-   "requirements":[  
+   "requirements":[
       [  
          "cold_frog"
       ],
@@ -72,6 +75,9 @@
       ],
       [
          "tadpole"
+      ],
+      [
+         "witch"
       ]
    ],
    "parent":"mobheads:firstmobhead"

--- a/achievements/achievements/data/mobheads/advancement/swampmobs.json
+++ b/achievements/achievements/data/mobheads/advancement/swampmobs.json
@@ -9,8 +9,7 @@
          "color":"white"
       },
       "icon":{  
-         "id":"mangrove_propagule",
-         "tag":0
+         "id":"mangrove_propagule"
       },
       "frame":"challenge"
    },
@@ -75,8 +74,5 @@
          "tadpole"
       ]
    ],
-   "filename":22,
-   "parent-count":3,
-   "parent-type":"parent",
    "parent":"mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/tamedwolf.json
+++ b/achievements/achievements/data/mobheads/advancement/tamedwolf.json
@@ -9,8 +9,7 @@
          "color":"white"
       },
       "icon":{
-         "id":"lead",
-		 "tag":0
+         "id":"lead"
       },
       "frame":"challenge",
       "hidden": false
@@ -80,9 +79,5 @@
       "tamed_spotted_wolf"
     ]
    ],
-     
-   "filename":21,
-   "parent-count":9,
-   "parent-type":"child",
    "parent":"mobheads:wildwolf"
 }

--- a/achievements/achievements/data/mobheads/advancement/thekillerbunny.json
+++ b/achievements/achievements/data/mobheads/advancement/thekillerbunny.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "golden_carrot",
-      "tag": 0
+      "id": "golden_carrot"
     },
     "frame": "challenge",
     "hidden": true
@@ -26,8 +25,5 @@
       "the_killer_bunny"
     ]
   ],
-  "filename": 20,
-  "parent-count": 8,
-  "parent-type": "child",
   "parent": "mobheads:rabbit"
 }

--- a/achievements/achievements/data/mobheads/advancement/thelegend27.json
+++ b/achievements/achievements/data/mobheads/advancement/thelegend27.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "dragon_head",
-      "tag": 0
+      "id": "dragon_head"
     },
     "frame": "challenge"
   },

--- a/achievements/achievements/data/mobheads/advancement/thelegend27.json
+++ b/achievements/achievements/data/mobheads/advancement/thelegend27.json
@@ -694,6 +694,21 @@
     },
     "derpy_snow_golem": {
       "trigger": "minecraft:impossible"
+    },
+    "parched": {
+      "trigger": "minecraft:impossible"
+    },
+    "camel_husk": {
+      "trigger": "minecraft:impossible"
+    },
+    "nautilus": {
+      "trigger": "minecraft:impossible"
+    },
+    "temperate_zombie_nautilus": {
+      "trigger": "minecraft:impossible"
+    },
+    "warm_zombie_nautilus": {
+      "trigger": "minecraft:impossible"
     }
   },
   "rewards": {
@@ -1382,6 +1397,21 @@
     ],
     [
       "derpy_snow_golem"
+    ],
+    [
+      "parched"
+    ],
+    [
+      "camel_husk"
+    ],
+    [
+      "nautilus"
+    ],
+    [
+      "temperate_zombie_nautilus"
+    ],
+    [
+      "warm_zombie_nautilus"
     ]
   ],
   "parent": "mobheads:root"

--- a/achievements/achievements/data/mobheads/advancement/thelegend27.json
+++ b/achievements/achievements/data/mobheads/advancement/thelegend27.json
@@ -566,7 +566,7 @@
     "ravager": {
       "trigger": "minecraft:impossible"
     },
-    "panda_agressive": {
+    "panda_aggressive": {
       "trigger": "minecraft:impossible"
     },
     "panda_brown": {
@@ -688,6 +688,12 @@
     },
     "oxidized_copper_golem":{
       "trigger":"minecraft:impossible"
+    },
+    "wither_skeleton": {
+      "trigger": "minecraft:impossible"
+    },
+    "derpy_snow_golem": {
+      "trigger": "minecraft:impossible"
     }
   },
   "rewards": {
@@ -1189,7 +1195,7 @@
       "ravager"
     ],
     [
-      "panda_agressive"
+      "panda_aggressive"
     ],
     [
       "panda_brown"
@@ -1370,6 +1376,12 @@
     ],
     [
       "oxidized_copper_golem"
+    ],
+    [
+      "wither_skeleton"
+    ],
+    [
+      "derpy_snow_golem"
     ]
   ],
   "parent": "mobheads:root"

--- a/achievements/achievements/data/mobheads/advancement/thelegend27.json
+++ b/achievements/achievements/data/mobheads/advancement/thelegend27.json
@@ -677,6 +677,18 @@
     },
     "tropical_fish_13": {
       "trigger": "minecraft:impossible"
+    },
+    "copper_golem":{
+      "trigger":"minecraft:impossible"
+    },
+    "exposed_copper_golem":{
+      "trigger":"minecraft:impossible"
+    },
+    "weathered_copper_golem":{
+      "trigger":"minecraft:impossible"
+    },
+    "oxidized_copper_golem":{
+      "trigger":"minecraft:impossible"
     }
   },
   "rewards": {
@@ -1347,6 +1359,18 @@
     ],
     [
       "warden"
+    ],
+    [
+      "copper_golem"
+    ],
+    [
+      "exposed_copper_golem"
+    ],
+    [
+      "weathered_copper_golem"
+    ],
+    [
+      "oxidized_copper_golem"
     ]
   ],
   "parent": "mobheads:root"

--- a/achievements/achievements/data/mobheads/advancement/thelegend27.json
+++ b/achievements/achievements/data/mobheads/advancement/thelegend27.json
@@ -33,10 +33,10 @@
     "Lucy_Axolotl": {
       "trigger": "minecraft:impossible"
     },
-    "goat_head1": {
+    "goat": {
       "trigger": "minecraft:impossible"
     },
-    "screaming_goat_head1": {
+    "screaming_goat": {
       "trigger": "minecraft:impossible"
     },
     "bat": {
@@ -75,10 +75,10 @@
     "warm_cow": {
       "trigger": "minecraft:impossible"
     },
-    "coldfroghead": {
+    "cold_frog": {
       "trigger": "minecraft:impossible"
     },
-    "coldfroggy": {
+    "cold_froggy": {
       "trigger": "minecraft:impossible"
     },
     "charged_creeper": {
@@ -91,6 +91,9 @@
       "trigger": "minecraft:impossible"
     },
     "drowned": {
+      "trigger": "minecraft:impossible"
+    },
+    "drowned_villager": {
       "trigger": "minecraft:impossible"
     },
     "elder_guardian": {
@@ -108,13 +111,13 @@
     "ghast": {
       "trigger": "minecraft:impossible"
     },
-    "glowsquidhead1": {
+    "glow_squid": {
       "trigger": "minecraft:impossible"
     },
-    "babyglowsquid": {
+    "baby_glow_squid": {
       "trigger": "minecraft:impossible"
     },
-    "babysquid": {
+    "baby_squid": {
       "trigger": "minecraft:impossible"
     },
     "guardian": {
@@ -141,10 +144,10 @@
     "gray_horse": {
       "trigger": "minecraft:impossible"
     },
-    "warmfroghead": {
+    "warm_frog": {
       "trigger": "minecraft:impossible"
     },
-    "warmfroggy": {
+    "warm_froggy": {
       "trigger": "minecraft:impossible"
     },
     "white_horse": {
@@ -169,6 +172,18 @@
       "trigger": "minecraft:impossible"
     },
     "white_llama": {
+      "trigger": "minecraft:impossible"
+    },
+    "brown_llama_trader": {
+      "trigger": "minecraft:impossible"
+    },
+    "creamy_llama_trader": {
+      "trigger": "minecraft:impossible"
+    },
+    "gray_llama_trader": {
+      "trigger": "minecraft:impossible"
+    },
+    "white_llama_trader": {
       "trigger": "minecraft:impossible"
     },
     "magma_cube": {
@@ -315,7 +330,7 @@
     "spider": {
       "trigger": "minecraft:impossible"
     },
-    "squidhead1": {
+    "squid": {
       "trigger": "minecraft:impossible"
     },
     "stray": {
@@ -324,10 +339,10 @@
     "tadpole": {
       "trigger": "minecraft:impossible"
     },
-    "temperatefroghead": {
+    "temperate_frog": {
       "trigger": "minecraft:impossible"
     },
-    "temperatefroggy": {
+    "temperate_froggy": {
       "trigger": "minecraft:impossible"
     },
     "turtle": {
@@ -507,10 +522,10 @@
     "bogged": {
       "trigger": "minecraft:impossible"
     },
-    "armadillo_head1": {
+    "armadillo": {
       "trigger": "minecraft:impossible"
     },
-    "armadillo_head2": {
+    "scared_armadillo": {
       "trigger": "minecraft:impossible"
     },
     "creeper": {
@@ -692,10 +707,10 @@
       "cod"
     ],
     [
-      "goat_head1"
+      "goat"
     ],
     [
-      "screaming_goat_head1"
+      "screaming_goat"
     ],
     [
       "temperate_cow"
@@ -717,6 +732,9 @@
     ],
     [
       "drowned"
+    ],
+    [
+      "drowned_villager"
     ],
     [
       "elder_guardian"
@@ -777,6 +795,18 @@
     ],
     [
       "white_llama"
+    ],
+    [
+      "brown_llama_trader"
+    ],
+    [
+      "creamy_llama_trader"
+    ],
+    [
+      "gray_llama_trader"
+    ],
+    [
+      "white_llama_trader"
     ],
     [
       "magma_cube"
@@ -914,10 +944,10 @@
       "spider"
     ],
     [
-      "squidhead1"
+      "squid"
     ],
     [
-      "babysquid"
+      "baby_squid"
     ],
     [
       "stray"
@@ -1100,10 +1130,10 @@
       "bogged"
     ],
     [
-      "armadillo_head1"
+      "armadillo"
     ],
     [
-      "armadillo_head2"
+      "scared_armadillo"
     ],
     [
       "breeze"
@@ -1226,31 +1256,31 @@
       "camel"
     ],
     [
-      "coldfroghead"
+      "cold_frog"
     ],
     [
-      "coldfroggy"
+      "cold_froggy"
     ],
     [
-      "warmfroghead"
+      "warm_frog"
     ],
     [
-      "warmfroggy"
+      "warm_froggy"
     ],
     [
-      "temperatefroghead"
+      "temperate_frog"
     ],
     [
-      "temperatefroggy"
+      "temperate_froggy"
     ],
     [
       "tadpole"
     ],
     [
-      "glowsquidhead1"
+      "glow_squid"
     ],
     [
-      "babyglowsquid"
+      "baby_glow_squid"
     ],
     [
       "sniffer"

--- a/achievements/achievements/data/mobheads/advancement/traderllama.json
+++ b/achievements/achievements/data/mobheads/advancement/traderllama.json
@@ -9,8 +9,7 @@
 			"color": "white"
 		},
 		"icon": {
-			"id": "lead",
-			"tag": 0
+			"id": "lead"
 		},
 		"frame": "challenge",
         "hidden": true
@@ -36,8 +35,5 @@
 		["creamy_llama_trader"],
 		["brown_llama_trader"]
 	],
-	"filename": 30,
-	"parent-count": 13,
-    "parent-type": "child",
     "parent": "mobheads:llama"
 }

--- a/achievements/achievements/data/mobheads/advancement/villagerheads.json
+++ b/achievements/achievements/data/mobheads/advancement/villagerheads.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "emerald",
-      "tag": 0
+      "id": "emerald"
     },
     "frame": "challenge"
   },
@@ -109,8 +108,5 @@
       "villager_toolsmith"
     ]
   ],
-  "filename": 26,
-  "parent-count": 3,
-  "parent-type": "parent",
   "parent": "mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/wanderer.json
+++ b/achievements/achievements/data/mobheads/advancement/wanderer.json
@@ -1,0 +1,28 @@
+{
+  "display": {
+    "description": {
+      "text": "Obtain the wandering trader's head",
+      "color": "white"
+    },
+    "title": {
+      "text": "Stranger Danger",
+      "color": "blue"
+    },
+    "icon": {
+      "id": "blue_dye"
+    },
+    "frame": "challenge"
+  },
+  "criteria": {
+    "wandering_trader": {
+      "trigger": "minecraft:impossible"
+    }
+  },
+  "rewards": {},
+  "requirements": [
+    [
+      "wandering_trader"
+    ]
+  ],
+  "parent": "mobheads:firstmobhead"
+}

--- a/achievements/achievements/data/mobheads/advancement/watermobs.json
+++ b/achievements/achievements/data/mobheads/advancement/watermobs.json
@@ -24,6 +24,9 @@
       "drowned":{  
          "trigger":"minecraft:impossible"
       },
+      "drowned_villager":{
+         "trigger":"minecraft:impossible"
+       },
       "elder_guardian":{  
          "trigger":"minecraft:impossible"
       },
@@ -36,16 +39,16 @@
       "salmon":{  
          "trigger":"minecraft:impossible"
       },
-      "glowsquidhead1":{  
+      "glow_squid":{
          "trigger":"minecraft:impossible"
       },
-      "babyglowsquid":{  
+      "baby_glow_squid":{
          "trigger":"minecraft:impossible"
       },
-      "squidhead1":{  
+      "squid":{
          "trigger":"minecraft:impossible"
       },
-      "babysquid":{  
+      "baby_squid":{
          "trigger":"minecraft:impossible"
       },
       "turtle":{  
@@ -119,6 +122,9 @@
       [  
          "drowned"
       ],
+      [
+         "drowned_villager"
+      ],
       [  
          "elder_guardian"
       ],
@@ -132,7 +138,7 @@
          "salmon"
       ],
       [  
-         "glowsquidhead1" 
+         "glow_squid"
       ],
       [   
          "guardian"
@@ -141,13 +147,13 @@
          "salmon"
       ],
       [   
-         "babyglowsquid" 
+         "baby_glow_squid"
       ],
       [ 
-         "squidhead1"
+         "squid"
       ],
       [   
-         "babysquid" 
+         "baby_squid"
       ],
       [ 
          "turtle"

--- a/achievements/achievements/data/mobheads/advancement/watermobs.json
+++ b/achievements/achievements/data/mobheads/advancement/watermobs.json
@@ -9,8 +9,7 @@
          "color":"white"
       },
       "icon":{  
-         "id":"trident",
-         "tag":0
+         "id":"trident"
       },
       "frame":"challenge"
    },
@@ -213,8 +212,5 @@
          "Lucy_Axolotl"
       ]
    ],
-   "filename":9,
-   "parent-count":3,
-   "parent-type":"parent",
    "parent":"mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/watermobs.json
+++ b/achievements/achievements/data/mobheads/advancement/watermobs.json
@@ -106,7 +106,16 @@
       },
       "tropical_fish_13": {
         "trigger": "minecraft:impossible"
-    }
+      },
+      "nautilus": {
+        "trigger": "minecraft:impossible"
+      },
+      "temperate_zombie_nautilus": {
+        "trigger": "minecraft:impossible"
+      },
+      "warm_zombie_nautilus": {
+        "trigger": "minecraft:impossible"
+      }
   },
    "rewards":{  
 
@@ -208,8 +217,17 @@
       [
          "tropical_fish_13"
       ],
-      [  
+      [
          "Lucy_Axolotl"
+      ],
+      [
+         "nautilus"
+      ],
+      [
+         "temperate_zombie_nautilus"
+      ],
+      [
+         "warm_zombie_nautilus"
       ]
    ],
    "parent":"mobheads:firstmobhead"

--- a/achievements/achievements/data/mobheads/advancement/wildwolf.json
+++ b/achievements/achievements/data/mobheads/advancement/wildwolf.json
@@ -9,8 +9,7 @@
          "color":"white"
       },
       "icon":{
-         "id":"bone",
-		 "tag":0
+         "id":"bone"
       },
       "frame":"challenge"
    },
@@ -81,9 +80,5 @@
       "wild_spotted_wolf"
     ]
    ],
-     
-   "filename":160,
-   "parent-count":3,
-   "parent-type":"parent",
    "parent":"mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/wither.json
+++ b/achievements/achievements/data/mobheads/advancement/wither.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "nether_star",
-      "tag": 0
+      "id": "nether_star"
     },
     "frame": "challenge"
   },
@@ -43,8 +42,5 @@
       "invulnerable_wither_1"
     ]
   ],
-  "filename": 18,
-  "parent-count": 3,
-  "parent-type": "parent",
   "parent": "mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/woodland_mansion.json
+++ b/achievements/achievements/data/mobheads/advancement/woodland_mansion.json
@@ -9,8 +9,7 @@
          "color":"white"
       },
       "icon":{
-         "id":"totem_of_undying",
-		 "tag": 0
+         "id":"totem_of_undying"
       },
       "frame":"challenge"
    },
@@ -39,8 +38,5 @@
          "evoker"
       ]
    ],
-   "filename":16,
-   "parent-count":3,
-   "parent-type":"parent",
    "parent":"mobheads:firstmobhead"
 }

--- a/achievements/achievements/data/mobheads/advancement/zombiehorse.json
+++ b/achievements/achievements/data/mobheads/advancement/zombiehorse.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "rotten_flesh",
-      "tag": 0
+      "id": "rotten_flesh"
     },
     "frame": "goal",
     "hidden": true
@@ -26,8 +25,5 @@
       "zombie_horse"
     ]
   ],
-  "filename": 21,
-  "parent-count": 12,
-  "parent-type": "child",
   "parent": "mobheads:horse"
 }

--- a/achievements/achievements/data/mobheads/advancement/zombievillagerheads.json
+++ b/achievements/achievements/data/mobheads/advancement/zombievillagerheads.json
@@ -9,8 +9,7 @@
       "color": "white"
     },
     "icon": {
-      "id": "zombie_villager_spawn_egg",
-      "tag": 0
+      "id": "zombie_villager_spawn_egg"
     },
     "frame": "challenge"
   },
@@ -110,7 +109,5 @@
       "zombie_weaponsmith_villager"
     ]
   ],
-  "filename": 27,
-  "parent-count": 3,
   "parent-type": "parent"
 }

--- a/config.yml
+++ b/config.yml
@@ -1496,7 +1496,7 @@ ListOfMobs:
     broadcastMessage: true
     displayName: "&eSnow Golem Head"
     random_uuid: f8184dd2-279c-4e04-8db5-177b63104adb
-    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMWZkZmQxZjc1MzhjMDQwMjU4YmU3YTkxNDQ2ZGE4OWVkODQ1Y2M1ZWY3MjhlYjVlNjkwNTQzMzc4ZmNmNCJ9fX0=
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYTI4YmNjOWU2MjI4YzBjM2E1NzMyYmI3ZDFlNzRlZjI4OWNkZjQ5MzVhN2RiNjNiYzUzNjYzN2U2ZmFkYzIzNiJ9fX0=
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 snow_golem"
@@ -1509,7 +1509,7 @@ ListOfMobs:
     broadcastMessage: true
     displayName: "&eDerpy Snow Golem Head"
     random_uuid: f8184dd2-279c-4e04-8db5-177b63104adc
-    textureCode: PLACEHOLDER_DERPY_SNOW_GOLEM
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMWZkZmQxZjc1MzhjMDQwMjU4YmU3YTkxNDQ2ZGE4OWVkODQ1Y2M1ZWY3MjhlYjVlNjkwNTQzMzc4ZmNmNCJ9fX0=
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 derpy_snow_golem"

--- a/config.yml
+++ b/config.yml
@@ -214,7 +214,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 warden"
-  Frog_Cold:
+  Cold_Frog:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
@@ -236,7 +236,7 @@ ListOfMobs:
           - "mobheads:firstmobhead first_mob_head"
           - "mobheads:thelegend27 cold_froggy"
           - "mobheads:swampmobs cold_froggy"
-  Frog_Warm:
+  Warm_Frog:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
@@ -258,7 +258,7 @@ ListOfMobs:
           - "mobheads:firstmobhead first_mob_head"
           - "mobheads:thelegend27 warm_froggy"
           - "mobheads:swampmobs warm_froggy"
-  Frog_Temperate:
+  Temperate_Frog:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
@@ -314,70 +314,101 @@ ListOfMobs:
         - "mobheads:firstmobhead first_mob_head"
         - "mobheads:thelegend27 baby_glow_squid"
         - "mobheads:watermobs baby_glow_squid"
-  Axolotl:
+  Lucy_Axolotl:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
     skullList:
-      AxolotlHead1:
-        displayName: "&eAxolotl Head"
+      LucyAxolotl:
+        displayName: "&eLucy Axolotl Head"
         random_uuid: 038a9627-18e4-4794-a241-2d477462352
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGViZjJiMTEzZjRhODEzNzBhMWNmOWQyNTA0ZTg3NTZiNjZkZWVmNzllOTQzMzE4N2RhNzc0Yjk2YzlmMzViYSJ9fX0=
         advancements:
           - "mobheads:firstmobhead first_mob_head"
-      AxolotlHead2:
-        displayName: "&eAxolotl Head"
-        random_uuid: 038a9627-18e4-4794-a241-2d477462353
-        textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMWU4YzcwZTZhNTYxNjFlY2RjNmI3NTY3NDA3MGZiMzA4NzE0YTJiMmI3MGUxZTZkNzZiYzkyMGNlNmNlN2RlNiJ9fX0=
-        advancements:
-          - "mobheads:firstmobhead first_mob_head"
-      AxolotlHead3:
-        displayName: "&eAxolotl Head"
-        random_uuid: 038a9627-18e4-4794-a241-2d477462354
-        textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTQ2MWM0ZjJjYjFlZGE4ZTE0Y2Q1OWVmYjBiZjg5ZWEyMDc2ZjU0YTA4YjhiNmQwZGIwYmQwNzk3ZDk5YmVlOCJ9fX0=
-        advancements:
-          - "mobheads:firstmobhead first_mob_head"
-      AxolotlHead4:
-        displayName: "&eAxolotl Head"
+          - "mobheads:axolotl Lucy_Axolotl"
+      SlimeAxolotl:
+        displayName: "&eSlime Axolotl Head"
         random_uuid: 038a9627-18e4-4794-a241-2d477462355
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2NkMWUxMzhjM2ZiODhhMTMzMjQ2ZTdkMWI4MzZjNGMyODI3ZTcwNzgwYjgwOGI1ZTlkY2VjMjBkMzM2OWVmOCJ9fX0=
         advancements:
           - "mobheads:firstmobhead first_mob_head"
-      AxolotlHead5:
-        displayName: "&eAxolotl Head"
+          - "mobheads:axolotl Lucy_Axolotl"
+      BlackAxolotl:
+        displayName: "&eBlack Axolotl Head"
         random_uuid: 038a9627-18e4-4794-a241-2d477462356
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWY1NjFmNDAzYTljMjdhNWU3MmE0Njg0MzY5MGViNDM3ODg1MjI5YTlkZTZjMjVlYmMyMWI5M2U2ZmRjZDliZCJ9fX0=
         advancements:
           - "mobheads:firstmobhead first_mob_head"
-      AxolotlHead6:
-        displayName: "&eAxolotl Head"
-        random_uuid: 038a9627-18e4-4794-a241-2d477462357
-        textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMjgyNjg3YzBlMzJmODBmYmYyNzUyZjJhNzVjM2JiZTBjZTk1MjU3MDRiNjVhNmQyNDFmNGM0NGRlMzk2MmE3MyJ9fX0=
-        advancements:
-          - "mobheads:firstmobhead first_mob_head"
+          - "mobheads:axolotl Lucy_Axolotl"
+  Cyan_Axolotl:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eCyan Axolotl Head"
+    random_uuid: 038a9627-18e4-4794-a241-2d477462353
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMWU4YzcwZTZhNTYxNjFlY2RjNmI3NTY3NDA3MGZiMzA4NzE0YTJiMmI3MGUxZTZkNzZiYzkyMGNlNmNlN2RlNiJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:axolotl Cyan_Axolotl"
+  Wild_Axolotl:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eWild Axolotl Head"
+    random_uuid: 038a9627-18e4-4794-a241-2d477462354
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTQ2MWM0ZjJjYjFlZGE4ZTE0Y2Q1OWVmYjBiZjg5ZWEyMDc2ZjU0YTA4YjhiNmQwZGIwYmQwNzk3ZDk5YmVlOCJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:axolotl Wild_Axolotl"
+  Gold_Axolotl:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eGold Axolotl Head"
+    random_uuid: 038a9627-18e4-4794-a241-2d477462360
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvM2E2NTM0YzMyYWI4NTYwMjg1NTg0NzgxMTVkOTA0ZDUyZjVmMTU0ZDgwZWNiOTAzYjg2NmIxOTA5OWEyNWU0NiJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:axolotl Gold_Axolotl"
+  Blue_Axolotl:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eBlue Axolotl Head"
+    random_uuid: 038a9627-18e4-4794-a241-2d477462357
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMjgyNjg3YzBlMzJmODBmYmYyNzUyZjJhNzVjM2JiZTBjZTk1MjU3MDRiNjVhNmQyNDFmNGM0NGRlMzk2MmE3MyJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:axolotl Blue_Axolotl"
   Goat:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
-    skullList:
-      GoatHead1:
-        displayName: "&eGoat Head"
-        random_uuid: 078a9627-18e4-4794-a241-2d477462350
-        textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDU3YTBkNTM4ZmEwOGE3YWZmZTMxMjkwMzQ2ODg2MTcyMGY5ZmEzNGU4NmQ0NGI4OWRjZWM1NjM5MjY1ZjAzIn19fQ==
-        advancements:
-          - "mobheads:firstmobhead first_mob_head"
-          - "mobheads:thelegend27 goat"
-          - "mobheads:goat goat"
-      GoatHead2:
-        displayName: "&eScreaming Goat Head"
-        random_uuid: 078a9627-18e4-4794-a241-2d477462351
-        textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjVjNzM0OWM3YjUzNDQzN2I2YmM5NTk0YzdlZDAwZmU1YjZjMWVjMDY0NmRjNGI4OTg0ZjM0ZWI0MTAzNzU4NCJ9fX0=
-        advancements:
-          - "mobheads:firstmobhead first_mob_head"
-          - "mobheads:thelegend27 screaming_goat"
-          - "mobheads:goat screaming_goat"
+    displayName: "&eGoat Head"
+    random_uuid: 078a9627-18e4-4794-a241-2d477462350
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDU3YTBkNTM4ZmEwOGE3YWZmZTMxMjkwMzQ2ODg2MTcyMGY5ZmEzNGU4NmQ0NGI4OWRjZWM1NjM5MjY1ZjAzIn19fQ==
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 goat"
+      - "mobheads:goat goat"
+  Screaming_Goat:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eScreaming Goat Head"
+    random_uuid: 078a9627-18e4-4794-a241-2d477462351
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjVjNzM0OWM3YjUzNDQzN2I2YmM5NTk0YzdlZDAwZmU1YjZjMWVjMDY0NmRjNGI4OTg0ZjM0ZWI0MTAzNzU4NCJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 screaming_goat"
+      - "mobheads:goat screaming_goat"
   Bat:
     dropChance: 0.75%
     lootingBonus: 1
@@ -1459,6 +1490,17 @@ ListOfMobs:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 snow_golem"
       - "mobheads:golem snow_golem"
+  Derpy_Snow_Golem:
+    dropChance: 1%
+    lootingBonus: 0.35%
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eDerpy Snow Golem Head"
+    random_uuid: f8184dd2-279c-4e04-8db5-177b63104adc
+    textureCode: PLACEHOLDER_DERPY_SNOW_GOLEM
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:golem derpy_snow_golem"
   Spider:
     dropChance: DEFAULT
     lootingBonus: DEFAULT

--- a/config.yml
+++ b/config.yml
@@ -164,6 +164,18 @@ ListOfMobs:
         - "mobheads:firstmobhead first_mob_head"
         - "mobheads:thelegend27 bogged"
         - "mobheads:swampmobs bogged"
+  Parched:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eParched Head"
+    random_uuid: a7f3c21e-5501-4b93-8d1f-9c42a87b6e01
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMjRhZWNlZmY1ZjI2ZGQ4NDEzYzVjMDM1NDdjMjM0YWMwMzEwOGQxODdhZjBiOWNkODM0YThjZTEyNTk4NTkxYyJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 parched"
+      - "mobheads:desert parched"
   Breeze:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -294,6 +306,45 @@ ListOfMobs:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 tadpole"
       - "mobheads:swampmobs tadpole"
+  Nautilus:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eNautilus Head"
+    random_uuid: c9f5e430-7723-4d15-af31-be64ca9d8023
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvM2JiMzQwZGQzMzAyNjE1MzQ4ZGU1MTYyZmUxNjcwYjljNWM5YzYxNmNkOTJkMmRlOWQ4Mzk4Y2IzM2U4NDJhZSJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 nautilus"
+      - "mobheads:watermobs nautilus"
+      - "mobheads:nautilus nautilus"
+  Temperate_Zombie_Nautilus:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eTemperate Zombie Nautilus Head"
+    random_uuid: da061541-8834-4e26-b042-cf75db0e9134
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZmQ5YTkzMzM3NmRhNDRjMzM5MTMwN2NiOWY0Y2YwM2YxNmYzYTU0ZjQ5NWZkNWExMWJhZDhhMzczZjlkNTcyMCJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 temperate_zombie_nautilus"
+      - "mobheads:watermobs temperate_zombie_nautilus"
+      - "mobheads:nautilus temperate_zombie_nautilus"
+  Warm_Zombie_Nautilus:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eWarm Zombie Nautilus Head"
+    random_uuid: eb172652-9945-4f37-c153-d086ec1f0245
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZDUxNmUxOGY0MDBiOGM0ODE5MGIzNDM4YTc1ZmVlZmRhNDUzNjdmMGFlNWQ0ZTQ5NzMyYzQxNzI1MTY1MGVjZiJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 warm_zombie_nautilus"
+      - "mobheads:watermobs warm_zombie_nautilus"
+      - "mobheads:nautilus warm_zombie_nautilus"
   Glow_Squid:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -435,6 +486,18 @@ ListOfMobs:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 camel"
       - "mobheads:desert camel"
+  Camel_Husk:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eCamel Husk Head"
+    random_uuid: b8e4d32f-6612-4c04-9e20-ad53b98c7f12
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvM2JkN2E5MmE2ZjY3Yjc1MDBkMTZjNGUxMmYyODA1OGVjMjg1OTMxMTU1NmJhMDNiZTJkMWY1ODExNzBmMmRiNiJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 camel_husk"
+      - "mobheads:desert camel_husk"
   Sniffer:
     dropChance: DEFAULT
     lootingBonus: DEFAULT

--- a/config.yml
+++ b/config.yml
@@ -141,6 +141,7 @@ ListOfMobs:
         advancements:
         - "mobheads:firstmobhead first_mob_head"
         - "mobheads:thelegend27 armadillo"
+        - "mobheads:desert armadillo"
       ArmadilloHead2:
         displayName: "&eScared Armadillo"
         random_uuid: 078a9627-18e4-4794-a241-2armi262349
@@ -148,6 +149,7 @@ ListOfMobs:
         advancements:
         - "mobheads:firstmobhead first_mob_head"
         - "mobheads:thelegend27 scared_armadillo"
+        - "mobheads:desert scared_armadillo"
   Bogged:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -420,6 +422,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 bat"
+      - "mobheads:night_mobs bat"
   Camel:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -431,6 +434,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 camel"
+      - "mobheads:desert camel"
   Sniffer:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -504,6 +508,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 cave_spider"
+      - "mobheads:arthropods cave_spider"
   Temperate_Chicken:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -594,6 +599,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 charged_creeper"
+      - "mobheads:night_mobs charged_creeper"
   Dolphin:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -833,6 +839,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 husk"
+      - "mobheads:desert husk"
   Illusioner:
     dropChance: 10%
     lootingBonus: 1%
@@ -979,6 +986,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 mooshroom"
+      - "mobheads:mushroom mooshroom"
   Mule:
     dropChance: 0.3%
     lootingBonus: DEFAULT
@@ -1073,6 +1081,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 phantom"
+      - "mobheads:night_mobs phantom"
   Temperate_Pig:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -1117,6 +1126,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 polar_bear"
+      - "mobheads:cold_biome polar_bear"
   Pufferfish:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -1466,6 +1476,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 silverfish"
+      - "mobheads:arthropods silverfish"
   Slime:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -1490,6 +1501,7 @@ ListOfMobs:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 snow_golem"
       - "mobheads:golem snow_golem"
+      - "mobheads:cold_biome snow_golem"
   Derpy_Snow_Golem:
     dropChance: 1%
     lootingBonus: 0.35%
@@ -1500,7 +1512,9 @@ ListOfMobs:
     textureCode: PLACEHOLDER_DERPY_SNOW_GOLEM
     advancements:
       - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 derpy_snow_golem"
       - "mobheads:golem derpy_snow_golem"
+      - "mobheads:cold_biome derpy_snow_golem"
   Spider:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -1512,6 +1526,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 spider"
+      - "mobheads:arthropods spider"
   Squid:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -1545,6 +1560,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 stray"
+      - "mobheads:cold_biome stray"
   Tropical_Fish:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -1836,6 +1852,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 witch"
+      - "mobheads:swampmobs witch"
   Wild_Wolf:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -1957,6 +1974,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 bee"
+      - "mobheads:arthropods bee"
   Zombie_Butcher_Villager:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -2034,6 +2052,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 wandering_trader"
+      - "mobheads:wanderer wandering_trader"
 
 
   Pillager:
@@ -2047,6 +2066,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 pillager"
+      - "mobheads:raid pillager"
 
   Mooshroom_Brown:
     dropChance: 1%
@@ -2059,6 +2079,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 mooshroom_brown"
+      - "mobheads:mushroom mooshroom_brown"
 
   Ravager:
     dropChance: 2%
@@ -2071,6 +2092,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 ravager"
+      - "mobheads:raid ravager"
 
 
   Panda_Aggressive:
@@ -2348,6 +2370,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 zombie"
+      - "mobheads:night_mobs zombie"
   Skeleton:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -2359,6 +2382,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 skeleton"
+      - "mobheads:night_mobs skeleton"
   Wither_Skeleton:
     dropChance: NONE
     lootingBonus: NONE
@@ -2370,6 +2394,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 wither_skeleton"
+      - "mobheads:nether_dimension wither_skeleton"
   Creeper:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -2381,6 +2406,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 creeper"
+      - "mobheads:night_mobs creeper"
   Ender_Dragon:
     dropChance: 100%
     lootingBonus: 0%

--- a/config.yml
+++ b/config.yml
@@ -127,6 +127,7 @@ ListOfMobs:
     textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYmVlYTg0NWNjMGI1OGZmNzYzZGVjZmZlMTFjZDFjODQ1YzVkMDljM2IwNGZlODBiMDY2M2RhNWM3YzY5OWViMyJ9fX0=
     advancements:
       - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 allay"
   Armadillo:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -138,13 +139,15 @@ ListOfMobs:
         random_uuid: 078a9627-18e4-4794-a241-2armi162348
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTg1MmIzM2JhMjk0ZjU2MDA5MDc1MmQxMTNmZTcyOGNiYzdkZDA0MjAyOWEzOGQ1MzgyZDY1YTIxNDYwNjhiNyJ9fX0=
         advancements:
-          - "mobheads:firstmobhead first_mob_head"
+        - "mobheads:firstmobhead first_mob_head"
+        - "mobheads:thelegend27 armadillo"
       ArmadilloHead2:
         displayName: "&eScared Armadillo"
         random_uuid: 078a9627-18e4-4794-a241-2armi262349
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZTc4ODMzODQ0MzE5OTA5ZjEyMzg0MDUwMTVkODc0MGFlOTZjNmZiM2ZhNGM3MzllMWNkZmMzNzljZDdlOWE2In19fQ==
         advancements:
-          - "mobheads:firstmobhead first_mob_head"
+        - "mobheads:firstmobhead first_mob_head"
+        - "mobheads:thelegend27 scared_armadillo"
   Bogged:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -156,7 +159,9 @@ ListOfMobs:
         random_uuid: 078a9627-18e4-4794-a241-2bog1462348
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYTNiOTAwM2JhMmQwNTU2MmM3NTExOWI4YTYyMTg1YzY3MTMwZTkyODJmN2FjYmFjNGJjMjgyNGMyMWViOTVkOSJ9fX0=
         advancements:
-          - "mobheads:firstmobhead first_mob_head"
+        - "mobheads:firstmobhead first_mob_head"
+        - "mobheads:thelegend27 bogged"
+        - "mobheads:swampmobs bogged"
   Breeze:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -168,7 +173,8 @@ ListOfMobs:
         random_uuid: 078a9627-18e4-4794-a241-2brez162348
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYTI3NTcyOGFmN2U2YTI5Yzg4MTI1YjY3NWEzOWQ4OGFlOTkxOWJiNjFmZGMyMDAzMzdmZWQ2YWIwYzQ5ZDY1YyJ9fX0=
         advancements:
-          - "mobheads:firstmobhead first_mob_head"
+        - "mobheads:firstmobhead first_mob_head"
+        - "mobheads:thelegend27 breeze"
   Creaking:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -180,7 +186,9 @@ ListOfMobs:
         random_uuid: 078a9627-18e4-4794-a241-2d477462348
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzdiNWJlNzI3NjljY2ZmMWE2Y2I3N2M1ODQ4ZTAxZDdlNTcwNGEzZDM0OWMwNzM3ZmY5M2NiNTRkMDIzODBhYyJ9fX0=
         advancements:
-          - "mobheads:firstmobhead first_mob_head"
+        - "mobheads:firstmobhead first_mob_head"
+        - "mobheads:thelegend27 creaking"
+        - "mobheads:creaking creaking"
   Happy_Ghast:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -193,6 +201,8 @@ ListOfMobs:
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYTFhMzZjYjkzZDAxNjc1YzQ2MjJkZDVjOGQ4NzIxMTA5MTFlYzEyYzM3MmU4OWFmYThiYTAzODYyODY3ZjZmYiJ9fX0=
         advancements:
           - "mobheads:firstmobhead first_mob_head"
+          - "mobheads:thelegend27 happy_ghast"
+          - "mobheads:happyghast happy_ghast"
   Warden:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -203,6 +213,7 @@ ListOfMobs:
     textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2Y2NDgxYzdjNDM1YzM0ZjIxZGZmMTA0M2E0YzcwMzRjNDQ1YTM4M2E1NDM1ZmExZjJhNTAzYTM0OGFmZDYyZiJ9fX0=
     advancements:
       - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 warden"
   Frog_Cold:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -215,12 +226,16 @@ ListOfMobs:
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMjdiY2NjYzEyNWE0MTEwNDM0YTg1YzQwYWRhMDM5ZDA1MGYxNGVmN2RiMzRhMzQ0NDA2NzMxMGY4Y2U2OTYwNiJ9fX0=
         advancements:
           - "mobheads:firstmobhead first_mob_head"
+          - "mobheads:thelegend27 cold_frog"
+          - "mobheads:swampmobs cold_frog"
       ColdFroggy:
         displayName: "&eCold Frog"
         random_uuid: 078a9627-18e4-4794-a241-2d47643ad432
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2U2MmU4YTA0OGQwNDBlYjA1MzNiYTI2YTg2NmNkOWMyZDA5MjhjOTMxYzUwYjQ0ODJhYzNhMzI2MWZhYjZmMCJ9fX0=
         advancements:
           - "mobheads:firstmobhead first_mob_head"
+          - "mobheads:thelegend27 cold_froggy"
+          - "mobheads:swampmobs cold_froggy"
   Frog_Warm:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -233,12 +248,16 @@ ListOfMobs:
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMWU5MzEyYjViMmJhYjlhZDUxZWE0YjZhNDA3ZDZkMzkwYmI1MDQzNDA4NzU3Yjk3NmE3NTU2ODk4YWM0M2RlMCJ9fX0=
         advancements:
           - "mobheads:firstmobhead first_mob_head"
+          - "mobheads:thelegend27 warm_frog"
+          - "mobheads:swampmobs warm_frog"
       WarmFroggy:
         displayName: "&eWarm Frog"
         random_uuid: 078a9627-18e4-4794-a241-2d47643ad432
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZjc3MzE0ZmEwMzhlYzMxMzU3ODQ1YTkzMjc0YjRkYzg4NDEyNDY4NjcyOGZmZTBkZWQ5YzM1NDY2YWNhMGFhYiJ9fX0=
         advancements:
           - "mobheads:firstmobhead first_mob_head"
+          - "mobheads:thelegend27 warm_froggy"
+          - "mobheads:swampmobs warm_froggy"
   Frog_Temperate:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -251,12 +270,16 @@ ListOfMobs:
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMWYzZTI5ZGQ5NDdhMTc3ODk1ZjYxMjFkMjMzMWI2NWFjM2Y4OTZmZGE0YmRkMTE1MTQ5MWU0MGI4MDQ5NTJhNyJ9fX0=
         advancements:
           - "mobheads:firstmobhead first_mob_head"
+          - "mobheads:thelegend27 temperate_frog"
+          - "mobheads:swampmobs temperate_frog"
       TemperateFroggy:
         displayName: "&eTemperate Frog"
         random_uuid: 078a9627-18e4-4794-a241-2d47643ad432
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMjNjZTZmOTk5OGVkMmRhNzU3ZDFlNjM3MmYwNGVmYTIwZTU3ZGZjMTdjM2EwNjQ3ODY1N2JiZGY1MWMyZjJhMiJ9fX0=
         advancements:
           - "mobheads:firstmobhead first_mob_head"
+          - "mobheads:thelegend27 temperate_froggy"
+          - "mobheads:swampmobs temperate_froggy"
   Tadpole:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -267,6 +290,8 @@ ListOfMobs:
     textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTg3MDM1ZjUzNTIzMzRjMmNiYTZhYzRjNjVjMmI5MDU5NzM5ZDZkMGU4MzljMWRkOThkNzVkMmU3Nzk1Nzg0NyJ9fX0=
     advancements:
       - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 tadpole"
+      - "mobheads:swampmobs tadpole"
   Glow_Squid:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -278,13 +303,17 @@ ListOfMobs:
         random_uuid: 078a9627-18e4-4794-a241-2d477462348
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTczMjdlZTExODEyYjc2NGM3YWRlNzBiMjgyY2NlNGM1OGU2MzViMjAxNTI0NDA4MWQxNDkwNTQzZGE3MjgwZSJ9fX0=
         advancements:
-          - "mobheads:firstmobhead first_mob_head"
+        - "mobheads:firstmobhead first_mob_head"
+        - "mobheads:thelegend27 glow_squid"
+        - "mobheads:watermobs glow_squid"
       BabyGlowSquid:
         displayName: "&eBaby Glow Squid"
         random_uuid: 078a9627-18e4-4794-a241-2d477462349
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTVlMmI0NmU1MmFjOTJkNDE5YTJkZGJjYzljZGNlN2I0NTFjYjQ4YWU3MzlkODVkNjA3ZGIwNTAyYTAwOGNlMCJ9fX0=
         advancements:
-          - "mobheads:firstmobhead first_mob_head"
+        - "mobheads:firstmobhead first_mob_head"
+        - "mobheads:thelegend27 baby_glow_squid"
+        - "mobheads:watermobs baby_glow_squid"
   Axolotl:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -339,12 +368,16 @@ ListOfMobs:
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDU3YTBkNTM4ZmEwOGE3YWZmZTMxMjkwMzQ2ODg2MTcyMGY5ZmEzNGU4NmQ0NGI4OWRjZWM1NjM5MjY1ZjAzIn19fQ==
         advancements:
           - "mobheads:firstmobhead first_mob_head"
+          - "mobheads:thelegend27 goat"
+          - "mobheads:goat goat"
       GoatHead2:
         displayName: "&eScreaming Goat Head"
         random_uuid: 078a9627-18e4-4794-a241-2d477462351
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjVjNzM0OWM3YjUzNDQzN2I2YmM5NTk0YzdlZDAwZmU1YjZjMWVjMDY0NmRjNGI4OTg0ZjM0ZWI0MTAzNzU4NCJ9fX0=
         advancements:
           - "mobheads:firstmobhead first_mob_head"
+          - "mobheads:thelegend27 screaming_goat"
+          - "mobheads:goat screaming_goat"
   Bat:
     dropChance: 0.75%
     lootingBonus: 1
@@ -366,6 +399,7 @@ ListOfMobs:
     textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYmE0Yzk1YmZhMGI2MTcyMjI1NTM4OTE0MWI1MDVjZjFhMzhiYWQ5YjBlZjU0M2RlNjE5ZjBjYzkyMjFlZDk3NCJ9fX0=
     advancements:
       - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 camel"
   Sniffer:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -376,6 +410,7 @@ ListOfMobs:
     textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODdhZDkyMGE2NmUzOGNjMzQyNmE1YmZmMDg0NjY3ZTg3NzIxMTY5MTVlMjk4MDk4NTY3YzEzOWYyMjJlMmM0MiJ9fX0=
     advancements:
       - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 sniffer"
   Blaze:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -519,16 +554,16 @@ ListOfMobs:
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzNmN2NjZjYxZGJjM2Y5ZmU5YTYzMzNjZGUwYzBlMTQzOTllYjJlZWE3MWQzNGNmMjIzYjNhY2UyMjA1MSJ9fX0=
         advancements:
           - "mobheads:firstmobhead first_mob_head"
-          - "mobheads:thelegend27 drowned_1"
-          - "mobheads:watermobs drowned_1"
+          - "mobheads:thelegend27 drowned"
+          - "mobheads:watermobs drowned"
       Drowned_Villager:
         displayName: "&eDrowned Villager Head"
         random_uuid: 17bbc41e-be73-468b-854a-670f7a6972fd
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTZkYWY1MGVhZjc2YzNhNmQ1YWQzOWM5NjZmMjk4NzdiOTFkOTUwZGQxZTM3MTIyZTljODE5NTg1Yzg5ZDkyZSJ9fX0=
         advancements:
           - "mobheads:firstmobhead first_mob_head"
-          - "mobheads:thelegend27 drowned_2"
-          - "mobheads:watermobs drowned_2"
+          - "mobheads:thelegend27 drowned_villager"
+          - "mobheads:watermobs drowned_villager"
   Elder_Guardian:
     dropChance: 1%
     lootingBonus: 1%
@@ -605,7 +640,7 @@ ListOfMobs:
       - "mobheads:ocean_monument guardian"
       - "mobheads:watermobs guardian"
   Black_Horse:
-    dropChance: 0.3%
+    dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
@@ -617,7 +652,7 @@ ListOfMobs:
       - "mobheads:thelegend27 black_horse"
       - "mobheads:horse black_horse"
   Brown_Horse:
-    dropChance: 0.3%
+    dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
@@ -629,7 +664,7 @@ ListOfMobs:
       - "mobheads:thelegend27 brown_horse"
       - "mobheads:horse brown_horse"
   Chestnut_Horse:
-    dropChance: 0.3%
+    dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
@@ -641,7 +676,7 @@ ListOfMobs:
       - "mobheads:thelegend27 chestnut_horse"
       - "mobheads:horse chestnut_horse"
   Creamy_Horse:
-    dropChance: 0.3%
+    dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
@@ -653,7 +688,7 @@ ListOfMobs:
       - "mobheads:thelegend27 creamy_horse"
       - "mobheads:horse creamy_horse"
   Dark_Brown_Horse:
-    dropChance: 0.3%
+    dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
@@ -665,7 +700,7 @@ ListOfMobs:
       - "mobheads:thelegend27 dark_brown_horse"
       - "mobheads:horse dark_brown_horse"
   Gray_Horse:
-    dropChance: 0.3%
+    dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
@@ -677,7 +712,7 @@ ListOfMobs:
       - "mobheads:thelegend27 gray_horse"
       - "mobheads:horse gray_horse"
   White_Horse:
-    dropChance: 0.3%
+    dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
@@ -689,7 +724,7 @@ ListOfMobs:
       - "mobheads:thelegend27 white_horse"
       - "mobheads:horse white_horse"
   Skeleton_Horse:
-    dropChance: 0.3%
+    dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
@@ -702,8 +737,8 @@ ListOfMobs:
       - "mobheads:horse skeleton_horse"
   #Does not spawn naturally
   Zombie_Horse:
-    dropChance: 100%
-    lootingBonus: 0%
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
     displayName: "&eZombie Horse Head"
@@ -735,8 +770,8 @@ ListOfMobs:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:illusioner illusioner"
   Iron_Golem:
-    dropChance: 1%
-    lootingBonus: 1%
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
     displayName: "&eIron Golem Head"
@@ -745,8 +780,9 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 iron_golem"
+      - "mobheads:golem iron_golem"
   Brown_Llama:
-    dropChance: 0.3%
+    dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
@@ -758,7 +794,7 @@ ListOfMobs:
       - "mobheads:thelegend27 brown_llama"
       - "mobheads:llama brown_llama"
   Creamy_Llama:
-    dropChance: 0.3%
+    dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
@@ -770,7 +806,7 @@ ListOfMobs:
       - "mobheads:thelegend27 creamy_llama"
       - "mobheads:llama creamy_llama"
   Gray_Llama:
-    dropChance: 0.3%
+    dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
@@ -782,7 +818,7 @@ ListOfMobs:
       - "mobheads:thelegend27 gray_llama"
       - "mobheads:llama gray_llama"
   White_Llama:
-    dropChance: 0.3%
+    dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
     broadcastMessage: true
@@ -803,8 +839,9 @@ ListOfMobs:
     textureCode: eyJ0aW1lc3RhbXAiOjE1NzY4MDYxODQ1MzgsInByb2ZpbGVJZCI6Ijg0Zjk2ZjBmYTVkYzRlNTliZGM1OWYzYmVhMDBhNDkwIiwicHJvZmlsZU5hbWUiOiJab21iaWVfU3RyaWtlciIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9mOGVkNmE1ZDcyMjQzNWRiNTE5YTA3YjJlMDJhNDQ4NzU1YWUzZDYxMDc3OTRlMDRhM2JiYWRhMThiNjYwMWMwIn19fQ=
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 brown_llama"
-      - "mobheads:llama brown_llama"
+      - "mobheads:thelegend27 brown_llama_trader"
+      - "mobheads:llama brown_llama_trader"
+      - "mobheads:traderllama brown_llama_trader"
   Creamy_Llama_Trader:
     dropChance: 1%
     lootingBonus: DEFAULT
@@ -815,8 +852,9 @@ ListOfMobs:
     textureCode: eyJ0aW1lc3RhbXAiOjE1NzY4MDYzNjU3MjksInByb2ZpbGVJZCI6Ijg0Zjk2ZjBmYTVkYzRlNTliZGM1OWYzYmVhMDBhNDkwIiwicHJvZmlsZU5hbWUiOiJab21iaWVfU3RyaWtlciIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS82NjJlMmZjMjZjMzVmNzA1MjVmMDkzYWQ4NmE1NjVjMzVhZDk1NDViZTllOTkxNzExOGNiNmM3ZTQ2MDdmMTg2In19fQ
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 creamy_llama"
-      - "mobheads:llama creamy_llama"
+      - "mobheads:thelegend27 creamy_llama_trader"
+      - "mobheads:llama creamy_llama_trader"
+      - "mobheads:traderllama creamy_llama_trader"
   Gray_Llama_Trader:
     dropChance: 1%
     lootingBonus: DEFAULT
@@ -827,8 +865,9 @@ ListOfMobs:
     textureCode: eyJ0aW1lc3RhbXAiOjE1NzY4MDY0MDA3MzgsInByb2ZpbGVJZCI6Ijg0Zjk2ZjBmYTVkYzRlNTliZGM1OWYzYmVhMDBhNDkwIiwicHJvZmlsZU5hbWUiOiJab21iaWVfU3RyaWtlciIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS82MjBjMWVmNzdiNmYzMGY3NzA1N2EyZDRlYjZhY2YxMDViMzM5M2IyNmJkMGQ1OGFjZTk3ZDc3YjAzMThmNDg2In19fQ
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 gray_llama"
-      - "mobheads:llama gray_llama"
+      - "mobheads:thelegend27 gray_llama_trader"
+      - "mobheads:llama gray_llama_trader"
+      - "mobheads:traderllama gray_llama_trader"
   White_Llama_Trader:
     dropChance: 1%
     lootingBonus: DEFAULT
@@ -839,8 +878,9 @@ ListOfMobs:
     textureCode: eyJ0aW1lc3RhbXAiOjE1NzY4MDY0MzA4NjIsInByb2ZpbGVJZCI6Ijg0Zjk2ZjBmYTVkYzRlNTliZGM1OWYzYmVhMDBhNDkwIiwicHJvZmlsZU5hbWUiOiJab21iaWVfU3RyaWtlciIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9kMTBkY2U5MWM1ZDlhYWNmN2JmMjk3YTUxN2U2MDNjYTliNTIyNTU5MDRjYmQ2ZDg4YzI0MmVkNTI4ODhiYzE3In19fQ=
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 white_llama"
-      - "mobheads:llama white_llama"
+      - "mobheads:thelegend27 white_llama_trader"
+      - "mobheads:llama white_llama_trader"
+      - "mobheads:traderllama white_llama_trader"
   Magma_Cube:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -958,7 +998,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 phantom"
-  Pig:
+  Temperate_Pig:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
@@ -968,7 +1008,29 @@ ListOfMobs:
     textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjIxNjY4ZWY3Y2I3OWRkOWMyMmNlM2QxZjNmNGNiNmUyNTU5ODkzYjZkZjRhNDY5NTE0ZTY2N2MxNmFhNCJ9fX0=
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 pig"
+      - "mobheads:thelegend27 temperate_pig"
+  Cold_Pig:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eCold Pig Head"
+    random_uuid: bffb9c02-b8d0-4358-bac2-4cpb591f1388
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYmExOGQ0MDQzY2Q2YzkwMzg2Njc4ODkxNGZkNTM0MzE1MjgxYWY5ZjI1OWUzNDgzN2UzZTE3NWU1NDVjMmVkZSJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 cold_pig"
+  Warm_Pig:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eWarm Pig Head"
+    random_uuid: bffb9c02-b8d0-4358-bac2-4wpb591f1388
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvN2JlYmExYTJkNTZlODRmOGU1MWZlZDY2NTlmMmNiN2MxNGZlZDQzODU5YWY1ODQ3Mzc4OTdiZjcwYzAzOTQ3NSJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 warm_pig"
   Polar_Bear:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -1340,6 +1402,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 slime"
+      - "mobheads:swampmobs slime"
   Snow_Golem:
     dropChance: 1%
     lootingBonus: 0.35%
@@ -1351,6 +1414,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 snow_golem"
+      - "mobheads:golem snow_golem"
   Spider:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -1374,16 +1438,16 @@ ListOfMobs:
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMDE0MzNiZTI0MjM2NmFmMTI2ZGE0MzRiODczNWRmMWViNWIzY2IyY2VkZTM5MTQ1OTc0ZTljNDgzNjA3YmFjIn19fQ==
         advancements:
           - "mobheads:firstmobhead first_mob_head"
-          - "mobheads:thelegend27 squid_1"
-          - "mobheads:watermobs squid_1"
+          - "mobheads:thelegend27 squid"
+          - "mobheads:watermobs squid"
       BabySquid:
         displayName: "&eBaby Squid"
         random_uuid: 078a9627-18e4-4794-a241-2d47643adfa2
         textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDljMmM5Y2U2N2ViNTk3MWNjNTk1ODQ2M2U2YzlhYmFiOGU1OTlhZGMyOTVmNGQ0MjQ5OTM2YjAwOTU3NjlkZCJ9fX0=
         advancements:
           - "mobheads:firstmobhead first_mob_head"
-          - "mobheads:thelegend27 squid_2"
-          - "mobheads:watermobs squid_2"
+          - "mobheads:thelegend27 baby_squid"
+          - "mobheads:watermobs baby_squid"
   Stray:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -1563,7 +1627,7 @@ ListOfMobs:
     textureCode: eyJ0aW1lc3RhbXAiOjE1NzY4MDc3MzMwMzIsInByb2ZpbGVJZCI6Ijg0Zjk2ZjBmYTVkYzRlNTliZGM1OWYzYmVhMDBhNDkwIiwicHJvZmlsZU5hbWUiOiJab21iaWVfU3RyaWtlciIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS83NWY1NmM3OWZjMDQ1NDI5NzE2NDYwYTVjZGZmZTYyNzQ2YmEwYTk5ZmRjZDBhODZjZWIzMjNlYjdiOTgwYzliIn19fQ
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 villager"
+      - "mobheads:thelegend27 villager_armorer"
   Villager_Butcher:
     dropChance: 1
     lootingBonus: DEFAULT
@@ -1574,7 +1638,7 @@ ListOfMobs:
     textureCode: eyJ0aW1lc3RhbXAiOjE1NzY4MDc4MjcwMjQsInByb2ZpbGVJZCI6Ijg0Zjk2ZjBmYTVkYzRlNTliZGM1OWYzYmVhMDBhNDkwIiwicHJvZmlsZU5hbWUiOiJab21iaWVfU3RyaWtlciIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS8zZTA1OWRiNDc0Y2Y1OTFkM2Y4NDVhZTVhYzEyNWU3Mjc1OWZhYzlhZDc0YmM5ODQ3NjViNTRlMjdjMWI4MDMwIn19fQ
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 villager"
+      - "mobheads:thelegend27 villager_butcher"
   Villager_Cartographer:
     dropChance: 1
     lootingBonus: DEFAULT
@@ -1585,7 +1649,7 @@ ListOfMobs:
     textureCode: eyJ0aW1lc3RhbXAiOjE1NzY4MDc4NjEwNzUsInByb2ZpbGVJZCI6Ijg0Zjk2ZjBmYTVkYzRlNTliZGM1OWYzYmVhMDBhNDkwIiwicHJvZmlsZU5hbWUiOiJab21iaWVfU3RyaWtlciIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS8zYWZkMDUzMDZkOTI3MGRjOGJmOWZkOGJjMzYyYzFlM2RkZjUyYzYzOWEwYzA1MmJmNmQwNWJmNDA1NDUzMWUyIn19fQ
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 villager"
+      - "mobheads:thelegend27 villager_cartographer"
   Villager_Cleric:
     dropChance: 1
     lootingBonus: DEFAULT
@@ -1596,7 +1660,7 @@ ListOfMobs:
     textureCode: eyJ0aW1lc3RhbXAiOjE1NzY4MDc4OTIzNTAsInByb2ZpbGVJZCI6Ijg0Zjk2ZjBmYTVkYzRlNTliZGM1OWYzYmVhMDBhNDkwIiwicHJvZmlsZU5hbWUiOiJab21iaWVfU3RyaWtlciIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS84NDc4OTQ4MzU4YTZmMmViMjgwNzVjY2Q5ODc5NWQ3ZTVkODMzYzlhZmNjODFkMWY3MWEzYjk1ODA4OGRmNmIzIn19fQ
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 villager"
+      - "mobheads:thelegend27 villager_cleric"
   Villager_Farmer:
     dropChance: 1
     lootingBonus: DEFAULT
@@ -1607,7 +1671,7 @@ ListOfMobs:
     textureCode: eyJ0aW1lc3RhbXAiOjE1NzY4MDc5NTc2MzYsInByb2ZpbGVJZCI6Ijg0Zjk2ZjBmYTVkYzRlNTliZGM1OWYzYmVhMDBhNDkwIiwicHJvZmlsZU5hbWUiOiJab21iaWVfU3RyaWtlciIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS82MDUzYjBhOTYwZjI1NTQyNDI4NzI5ODE1M2Y0YjU5ZGRjNTM0Mjc0ZDJlODA0Yzk4NWZmODYwOWJkZDQyMzI1In19fQ
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 villager"
+      - "mobheads:thelegend27 villager_farmer"
   Villager_Fisherman:
     dropChance: 1
     lootingBonus: DEFAULT
@@ -1618,7 +1682,7 @@ ListOfMobs:
     textureCode: eyJ0aW1lc3RhbXAiOjE1NzY4MDgwMTAzMjYsInByb2ZpbGVJZCI6Ijg0Zjk2ZjBmYTVkYzRlNTliZGM1OWYzYmVhMDBhNDkwIiwicHJvZmlsZU5hbWUiOiJab21iaWVfU3RyaWtlciIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9kYjQ0MjI1YmFjMjAzZDIwMzc2MWM5NDVlMjU2ZDFkYzU3YTI1OWNiZDdlOTkzMjY4MDdmMjIxOGNjNzE3MzBjIn19fQ
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 villager"
+      - "mobheads:thelegend27 villager_fisherman"
   Villager_Fletcher:
     dropChance: 1
     lootingBonus: DEFAULT
@@ -1629,7 +1693,7 @@ ListOfMobs:
     textureCode: eyJ0aW1lc3RhbXAiOjE1NzY4MDgwNDMzMTgsInByb2ZpbGVJZCI6Ijg0Zjk2ZjBmYTVkYzRlNTliZGM1OWYzYmVhMDBhNDkwIiwicHJvZmlsZU5hbWUiOiJab21iaWVfU3RyaWtlciIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS8yZTUwN2VlZmMwZDFmMGY0NzExYjgyZmU5MzEwODU5MmRjNWI1ZGU2ZjgzZmZlMzhhNmE1ZjA3MDhjMTA0ODVkIn19fQ
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 villager"
+      - "mobheads:thelegend27 villager_fletcher"
   Villager_Librarian:
     dropChance: 1
     lootingBonus: DEFAULT
@@ -1640,7 +1704,7 @@ ListOfMobs:
     textureCode: eyJ0aW1lc3RhbXAiOjE1NzY4MDgwNzQ5NTQsInByb2ZpbGVJZCI6Ijg0Zjk2ZjBmYTVkYzRlNTliZGM1OWYzYmVhMDBhNDkwIiwicHJvZmlsZU5hbWUiOiJab21iaWVfU3RyaWtlciIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9kYzc4NGYwYWVhY2I4NjdhYjU2M2Q5NWRkNWVjNjQ5NmU4N2ZjMjFmZjc5OGNhYmNhMmE4OTc0Y2M0OWU4ZTU2In19fQ
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 villager"
+      - "mobheads:thelegend27 villager_librarian"
   Villager_Shepherd:
     dropChance: 1
     lootingBonus: DEFAULT
@@ -1651,7 +1715,7 @@ ListOfMobs:
     textureCode: eyJ0aW1lc3RhbXAiOjE1NzY4MDgxMTg1MjQsInByb2ZpbGVJZCI6Ijg0Zjk2ZjBmYTVkYzRlNTliZGM1OWYzYmVhMDBhNDkwIiwicHJvZmlsZU5hbWUiOiJab21iaWVfU3RyaWtlciIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9mMDIzYjNhNDBjYTQ5Y2I1YjVlYTY1MzVlOTNmNzA5NGYxOGI3MjA0NGQ5NTU4MDU1NDE2MWJhYzg5NmFiMTVjIn19fQ
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 villager"
+      - "mobheads:thelegend27 villager_shepherd"
   Villager_Weaponsmith:
     dropChance: 1
     lootingBonus: DEFAULT
@@ -1662,7 +1726,7 @@ ListOfMobs:
     textureCode: eyJ0aW1lc3RhbXAiOjE1NzY4MDgxNjUxMzUsInByb2ZpbGVJZCI6Ijg0Zjk2ZjBmYTVkYzRlNTliZGM1OWYzYmVhMDBhNDkwIiwicHJvZmlsZU5hbWUiOiJab21iaWVfU3RyaWtlciIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS84N2YwY2YxMTQwMGUzZWVkODc2MTVlY2Q3YTA5OTg3MzhiNThlMzBmYzYzNjZmMDc3OTllMWQ3ZDY0YjkyNTMifX19
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 villager"
+      - "mobheads:thelegend27 villager_weaponsmith"
   Vindicator:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -1933,8 +1997,8 @@ ListOfMobs:
     textureCode: eyJ0aW1lc3RhbXAiOjE1NjUyMTIzMDUzNTgsInByb2ZpbGVJZCI6Ijg0Zjk2ZjBmYTVkYzRlNTliZGM1OWYzYmVhMDBhNDkwIiwicHJvZmlsZU5hbWUiOiJab21iaWVfU3RyaWtlciIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9mM2NhMGRiZjliM2M4YjcxMGI0OTM4OTc4ZTk0Y2ZjYTIzN2YwMmViM2E5YjdkNmQzZGZmNjA2NTAxYTdiYWMxIn19fQ
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 panda_agressive"
-      - "mobheads:panda panda_agressive"
+      - "mobheads:thelegend27 panda_aggressive"
+      - "mobheads:panda panda_aggressive"
 
 
   Panda_Brown:

--- a/config.yml
+++ b/config.yml
@@ -473,7 +473,7 @@ ListOfMobs:
     advancements:
       - "mobheads:firstmobhead first_mob_head"
       - "mobheads:thelegend27 cave_spider"
-  Chicken:
+  Temperate_Chicken:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
@@ -483,7 +483,29 @@ ListOfMobs:
     textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTYzODQ2OWE1OTljZWVmNzIwNzUzNzYwMzI0OGE5YWIxMWZmNTkxZmQzNzhiZWE0NzM1YjM0NmE3ZmFlODkzIn19fQ==
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 chicken"
+      - "mobheads:thelegend27 temperate_chicken"
+  Cold_Chicken:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eChicken[Cold] Head"
+    random_uuid: 0d579158-bfd4-4845-beb3-7cceb056987f
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYTkxMWZjZDhiMjI2YTk4ZjhiNmQ2MDVmZjI3YTg4ZWQ5NzIzMGJiNzE2NzhlNGEwMDY2OTA5NWQ2OWQzZjJiNCJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 cold_chicken"
+  Warm_Chicken:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eChicken[Warm] Head"
+    random_uuid: 0d579158-bfd4-4845-beb3-7wceb056987f
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNThjMjMxYmY0NjRmOWE2YzY3ODZhMjJhNGQxMTllYTVlNTA1NzYyNGM1YTM5MTQ3MGQzNWZhMmI2ZmZhNTE4MyJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 warm_chicken"
   Cod:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
@@ -497,7 +519,7 @@ ListOfMobs:
       - "mobheads:thelegend27 cod"
       - "mobheads:fish cod"
       - "mobheads:watermobs cod"
-  Cow:
+  Temperate_Cow:
     dropChance: DEFAULT
     lootingBonus: DEFAULT
     dropOnChargedCreeperDeath: true
@@ -507,7 +529,29 @@ ListOfMobs:
     textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNWQ2YzZlZGE5NDJmN2Y1ZjcxYzMxNjFjNzMwNmY0YWVkMzA3ZDgyODk1ZjlkMmIwN2FiNDUyNTcxOGVkYzUifX19
     advancements:
       - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 cow"
+      - "mobheads:thelegend27 temperate_cow"
+  Cold_Cow:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eCow[Cold] Head"
+    random_uuid: b32d23be-aeca-4f40-a813-accfbbec4372
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYWQwNjg4ODVkMmRmYTNhMzA5MzYzYWYwYTg3ZGNhNmZiZjYyOWY3MTMwNzRmOTY4NjIxOWQ3YmE3YWY3MDA4ZCJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 cold_cow"
+  Warm_Cow:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eCow[Warm] Head"
+    random_uuid: b32d23be-aeca-4f40-a813-awcfbbec4372
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMjNiMzM3NmZhZjI4MWMxNGJhNDcyZDJlN2Y2YjZkMDE2OWU0YmMyMzc0ODM1YTlmOGQwNzg4ZTA0ZDgxMzQzZCJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 warm_cow"
   Charged_Creeper:
     dropChance: 2%
     lootingBonus: 1%
@@ -2402,6 +2446,59 @@ ListOfFish:
       - "mobheads:thelegend27 pufferfish"
       - "mobheads:fish pufferfish"
       - "mobheads:watermobs pufferfish"
+
+  Copper_Golem:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eCopper Golem Head"
+    random_uuid: d23f3607-25a0-4c22-860a-0ucgb9a16412
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTllMjRlOTRkYmU0MmUyMzBkODMyOTNhNzdkNjFmZjcxMDFhOGM2OGFiNjhiYmM2YTkzZjk2MzBmYjJmZGI0In19fQ==
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 copper_golem"
+      - "mobheads:golem copper_golem"
+      - "mobheads:copperage copper_golem"
+  Exposed_Copper_Golem:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eExposed Copper Golem Head"
+    random_uuid: d23f3607-25a0-4c22-860a-0ecgb9a16412
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOGE5ZTQxMGM4YjdmZGJkNGI5ZDhlYTgwNzViYzY2YTljMWFkYTliYzE1ODczYjRiMWRlYWRhYTI4MTJiODQ3ZCJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 exposed_copper_golem"
+      - "mobheads:golem copper_golem"
+      - "mobheads:copperage exposed_copper_golem"
+  Weathered_Copper_Golem:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eWeathered Copper Golem Head"
+    random_uuid: d23f3607-25a0-4c22-860a-0wcgb9a16412
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODI2Mjk5MmQ2ZDVhNjJhMWRkM2VkZThlNGMzNGYxYzE4MDUwYmFiNjQyNzFkOTI2YzFjMGM2MTYyYjJjZDc0ZSJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 weathered_copper_golem"
+      - "mobheads:golem copper_golem"
+      - "mobheads:copperage weathered_copper_golem"
+  Oxidized_Copper_Golem:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eOxidized Copper Golem Head"
+    random_uuid: d23f3607-25a0-4c22-860a-0ocgb9a16412
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2MyYWFiOGEwZmVjM2NjMDZhNGQ0NzQ4MGUwMjRmODhmMmIwN2JjOTZlZTA5ZTUzMzFlNWY0ZGI2YjI3Mzg4NSJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 oxidized_copper_golem"
+      - "mobheads:golem copper_golem"
+      - "mobheads:copperage oxidized_copper_golem"
 
 #Whenever a player dies by another player
 Player:

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,7 +5,7 @@ authors:
     - CyberDrain
     - Zombie_Striker
     - Lord_Lofi
-api-version: 1.21.8
+api-version: 1.21.9
 description: Allows players to behead mobs and other players!
 commands:
     mobheads:

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,7 +5,7 @@ authors:
     - CyberDrain
     - Zombie_Striker
     - Lord_Lofi
-api-version: 1.21.9
+api-version: 1.21
 description: Allows players to behead mobs and other players!
 commands:
     mobheads:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.cyber</groupId>
     <artifactId>MobHeads</artifactId>
-    <version>4.0</version>
+    <version>5.0</version>
 
 
 
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.21.9-R0.1-SNAPSHOT</version>
+            <version>1.21.11-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- WorldGuard API -->

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.21.8-R0.1-SNAPSHOT</version>
+            <version>1.21.9-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- WorldGuard API -->

--- a/src/com/cyber/mobheads/Utilities/MobNames.java
+++ b/src/com/cyber/mobheads/Utilities/MobNames.java
@@ -16,7 +16,6 @@ public enum MobNames {
 	Breeze,
 	Camel,
 	Cave_Spider,
-	Copper_Golem,
 	Creaking,
 	Dolphin,
 	Donkey,
@@ -244,6 +243,12 @@ public enum MobNames {
 	//fox types
 	Fox_Normal,
 	Fox_Snow,
+
+	//copper golem types
+	Copper_Golem,
+	Exposed_Copper_Golem,
+	Oxidized_Copper_Golem,
+	Weathered_Copper_Golem,
 
 	//These are the invalid cats. Still have to load them:
 	Black_Cat,
@@ -644,10 +649,10 @@ public enum MobNames {
 	}
 
 	private static MobNames getCopperGolemName(CopperGolem coppergolem) {
-		if (coppergolem.getWeatheringState() == null) {
+		if (coppergolem.getWeatherState() == null) {
                 return Copper_Golem;
 		}
-		switch (coppergolem.getWeatheringState()) {
+		switch (coppergolem.getWeatherState()) {
 			case EXPOSED:
 				return Exposed_Copper_Golem;
 			case OXIDIZED:

--- a/src/com/cyber/mobheads/Utilities/MobNames.java
+++ b/src/com/cyber/mobheads/Utilities/MobNames.java
@@ -16,6 +16,7 @@ public enum MobNames {
 	Breeze,
 	Camel,
 	Cave_Spider,
+	Copper_Golem,
 	Creaking,
 	Dolphin,
 	Donkey,
@@ -287,6 +288,8 @@ public enum MobNames {
 				return Cave_Spider;
 			case CHICKEN:
 				return getChickenName((Chicken) entity);
+			case COPPER_GOLEM:
+				return getCopperGolemName((CopperGolem) entity);
 			case COW:
 				return getCowName((Cow) entity);
 			case CREAKING:
@@ -638,6 +641,23 @@ public enum MobNames {
 			return Derpy_Snow_Golem;
 		}
 		return Snow_Golem;
+	}
+
+	private static MobNames getCopperGolemName(CopperGolem coppergolem) {
+		if (coppergolem.getWeatheringState() == null) {
+                return Copper_Golem;
+		}
+		switch (coppergolem.getWeatheringState()) {
+			case EXPOSED:
+				return Exposed_Copper_Golem;
+			case OXIDIZED:
+				return Oxidized_Copper_Golem;
+			case WEATHERED:
+				return Weathered_Copper_Golem;
+			case UNAFFECTED:
+				return Copper_Golem;
+		}
+		return Copper_Golem;
 	}
 
 	private static MobNames getHorseName(Horse horse) {

--- a/src/com/cyber/mobheads/Utilities/MobNames.java
+++ b/src/com/cyber/mobheads/Utilities/MobNames.java
@@ -593,8 +593,7 @@ public enum MobNames {
 
 	private static MobNames getAxolotlName(Axolotl axolotl) {
 		if (axolotl.getVariant() == null) {
-                System.out.println("Warning: Axolotl variant is null!");
-                return null;
+			return null;
 		}
 		switch (axolotl.getVariant()) {
 			case BLUE:
@@ -608,7 +607,6 @@ public enum MobNames {
 			case WILD:
 				return Wild_Axolotl;
 		}
-        System.out.println("Warning: Unrecognized Axolotl variant: " + axolotl.getVariant());
 		return null;
 	}
 
@@ -834,13 +832,11 @@ public enum MobNames {
 	}
 
 	private static MobNames getWolfName(Wolf wolf) {
-		// Get the NamespacedKey of the wolf's variant
-		final NamespacedKey wolfVariantKey = wolf.getVariant().getKey();
 		if (wolf.isTamed()) {
-			// Check if the wolf's variant is null
 			if (wolf.getVariant() == null) {
 				return Tamed_Wolf;
 			}
+			final NamespacedKey wolfVariantKey = wolf.getVariant().getKey();
 
 			// Compare the key to the registry variants
 			if (wolfVariantKey.equals(Registry.WOLF_VARIANT.get(new NamespacedKey("minecraft", "ashen")).getKey())) {
@@ -873,10 +869,10 @@ public enum MobNames {
 			// Default return if no match is found
 			return Tamed_Wolf;
 		}
-		// Check if the wolf's variant is null
 		if (wolf.getVariant() == null) {
 			return Wild_Wolf;
 		}
+		final NamespacedKey wolfVariantKey = wolf.getVariant().getKey();
 
 		// Compare the key to the registry variants
 		if (wolfVariantKey.equals(Registry.WOLF_VARIANT.get(new NamespacedKey("minecraft", "ashen")).getKey())) {

--- a/src/com/cyber/mobheads/Utilities/MobNames.java
+++ b/src/com/cyber/mobheads/Utilities/MobNames.java
@@ -250,6 +250,15 @@ public enum MobNames {
 	Oxidized_Copper_Golem,
 	Weathered_Copper_Golem,
 
+	//nautilus types
+	Nautilus,
+	Temperate_Zombie_Nautilus,
+	Warm_Zombie_Nautilus,
+
+	//1.21.11 new mobs
+	Parched,
+	Camel_Husk,
+
 	//These are the invalid cats. Still have to load them:
 	Black_Cat,
 	Ginger_Cat,
@@ -289,6 +298,8 @@ public enum MobNames {
 				return Ocelot;
 			case CAMEL:
 				return Camel;
+			case CAMEL_HUSK:
+				return Camel_Husk;
 			case CAVE_SPIDER:
 				return Cave_Spider;
 			case CHICKEN:
@@ -375,6 +386,12 @@ public enum MobNames {
 				return Spider;
 			case SQUID:
 				return Squid;
+			case NAUTILUS:
+				return Nautilus;
+			case ZOMBIE_NAUTILUS:
+				return getZombieNautilusName((ZombieNautilus) entity);
+			case PARCHED:
+				return Parched;
 			case STRAY:
 				return Stray;
 			case TURTLE:
@@ -1003,6 +1020,19 @@ public enum MobNames {
 			return Villager_Weaponsmith;
 		}
 		return Villager;
+	}
+
+	private static MobNames getZombieNautilusName(ZombieNautilus zombieNautilus) {
+		if (zombieNautilus.getVariant() == null) {
+			return Temperate_Zombie_Nautilus;
+		}
+		if (zombieNautilus.getVariant() == ZombieNautilus.Variant.TEMPERATE) {
+			return Temperate_Zombie_Nautilus;
+		}
+		if (zombieNautilus.getVariant() == ZombieNautilus.Variant.WARM) {
+			return Warm_Zombie_Nautilus;
+		}
+		return Temperate_Zombie_Nautilus;
 	}
 
 	private static MobNames getFishName(Entity entity) {


### PR DESCRIPTION
MobHeads 5.0 - MC 1.21.11 Update

## API & Version
- Spigot API: 1.21.9-R0.1-SNAPSHOT -> 1.21.11-R0.1-SNAPSHOT
- Plugin version: 4.0 -> 5.0
- api-version: 1.21.9 -> 1.21

## Bug Fixes
- Frogs: renamed config keys to match enum (Cold_Frog, Warm_Frog, Temperate_Frog)
- Goat: split single skullList into separate Goat and Screaming_Goat config entries
- Axolotl: restored full 5-variant dispatch with separate config entries and correct textures
- Wolf: fixed NPE from getVariant().getKey() called before null check

## Copper Golem (1.21.10)
- Added 4 oxidation state variants: Copper_Golem, Exposed, Weathered, Oxidized
- getCopperGolemName() dispatches on CopperGolem.CopperWeatherState
- Config entries and textures for all 4 states
- copperage.json advancement covering all 4 variants

## Advancement Fixes
- Batch removed broken "tag":0 icon fields and stale metadata fields from all 35 files
- panda.json: "item" -> "id" in icon field
- player.json: removed stale "parent-type" field
- root.json: plain string title -> text component object
- golem.json: added derpy_snow_golem
- nether_dimension.json: added wither_skeleton
- swampmobs.json: added witch
- thelegend27.json: fixed panda_agressive typo; added wither_skeleton, derpy_snow_golem

## New Advancement Categories (8 new files)
- raid.json          "The Village Defenders"  - Pillager, Ravager
- arthropods.json    "Eight Legs Too Many"    - Spider, Cave Spider, Silverfish, Bee
- desert.json        "Sand in Your Head"      - Husk, Camel, Armadillo, Scared Armadillo, Parched, Camel Husk
- cold_biome.json    "It's Freezing Out Here" - Stray, Polar Bear, Snow Golem, Derpy Snow Golem
- mushroom.json      "Fun-gus Among Us"       - Mooshroom, Brown Mooshroom
- night_mobs.json    "Things That Go Bump"    - Zombie, Skeleton, Creeper, Charged Creeper, Phantom, Bat
- wanderer.json      "Stranger Danger"        - Wandering Trader
- nautilus.json      "Shell Shocked"          - Nautilus, Temperate Zombie Nautilus, Warm Zombie Nautilus

## Config Advancement References
- Added new advancement references to 24+ mob entries to unlock new achievements on head drop

## Snow Golem Head Split
- Snow_Golem: carved pumpkin skin
- Derpy_Snow_Golem: exposed snowman face skin (unique to sheared variant)

## New Mobs (1.21.11)
- Parched             - desert skeleton variant (PARCHED entity type, no variants)
- Camel_Husk          - undead camel variant (CAMEL_HUSK entity type, no variants)
- Nautilus            - aquatic tameable mount (NAUTILUS entity type, no variants)
- Temperate_Zombie_Nautilus - zombie nautilus (ZOMBIE_NAUTILUS + Variant.TEMPERATE)
- Warm_Zombie_Nautilus      - coral zombie nautilus (ZOMBIE_NAUTILUS + Variant.WARM)