### PR TITLE
1.21.11 patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,272 +1,359 @@
 # MobHeads
-Fork of fahlur's Fork of CyberDrain's plugin
 
+A Paper plugin that adds custom player-skull drops for nearly every mob in the game — including variant-aware drops for mobs like wolves, frogs, pandas, copper golems, and more. Heads are fully configurable with custom textures, drop chances, looting bonuses, broadcast messages, and advancement support.
 
--- Original Plugin page
-https://www.spigotmc.org/resources/ultimate-mob-heads-fork.70019/
+> Releases are available on the right-hand side of this page under **Releases**.
 
-Releases are located on the Right-Hand side -->
+---
+
+## Features
+
+- **200+ unique mob heads** — including per-variant drops for wolves, frogs, sheep, horses, villagers, axolotls, pandas, cats, and more
+- **Variant-aware drops** — a weathered copper golem drops a different head than an unaffected one; a screaming goat drops a different head than a regular goat
+- **Fully configurable** — set drop chance, looting bonus, display name, texture, broadcast message, and advancement triggers per mob
+- **Advancement integration** — grant players in-game advancements when they collect specific heads
+- **Charged creeper support** — guaranteed drops when a mob is killed by a charged creeper (configurable per mob)
+- **Fish heads** — obtainable while fishing, with Luck of the Sea bonus support
+- **WorldGuard support** — respects region flags
+- **bStats metrics**
+
+---
+
+## Requirements
+
+| Requirement | Version |
+|---|---|
+| Server software | [Paper](https://papermc.io) |
+| Minecraft | 1.21.11 |
+| Java | 17+ |
+
+> This plugin targets Paper specifically. It will not work correctly on vanilla Spigot due to API differences introduced in 1.21.10+.
+
+---
+
+## Installation
+
+1. Download the latest release JAR from the **Releases** section
+2. Drop it into your server's `plugins/` folder
+3. Restart the server — a default `config.yml` will be generated
+4. Adjust drop chances, textures, and other settings to your liking
+5. Use `/mh reload` to apply config changes without restarting
+
+---
+
+## Permissions
+
+| Permission | Description |
+|---|---|
+| `com.cyber.mobheads.behead.mobs` | Allows the player to receive mob heads on kill |
+| `com.cyber.mobheads.behead.players` | Allows the player to receive player heads on kill |
+
+---
+
+## Configuration
+
+The config is split into two sections:
+
+- **`ListOfMobs`** — all killable mob heads
+- **`ListOfFish`** — fish heads obtainable through fishing
+
+Each entry supports the following fields:
+
+```yaml
+Mob_Name:
+  dropChance: 0.25%        # Chance the head drops on kill (use DEFAULT to inherit global setting)
+  lootingBonus: 0.1%       # Added chance per looting level (use DEFAULT to inherit)
+  dropOnChargedCreeperDeath: true  # Whether a charged creeper guarantees the drop
+  broadcastMessage: true   # Announce the drop to the server
+  displayName: "&eMob Head"
+  random_uuid: <uuid>
+  textureCode: <base64>
+  advancements:
+    - "mobheads:category criteria_name"
+```
+
+Set `dropChance: NONE` to disable a specific head without removing the entry.
+
+---
+
+## Supported Mobs
 
 <details>
-  <summary>Supported Mob Names for Config File</summary>
-  
-  ### Supported Mob Names
-  ```yaml
-Allay,
-Armadillo,
-Bat,
-Bee,
-Blaze,
-Bogged,
-Breeze,
-Camel,
-Cave_Spider,
-Creaking,
-Dolphin,
-Donkey,
-Drowned,
-Elder_Guardian,
-Enderman,
-Endermite,
-Ender_Dragon,
-Evoker,
-Ghast,
-Giant,
-Glow_Squid,
-Guardian,
-Happy_Ghast,
-Hoglin,
-Husk,
-Illusioner,
-Iron_Golem,
-Magma_Cube,
-Mooshroom,
-Mooshroom_Brown,
-Mule,
-Ocelot,
-Phantom,
-Piglin,
-Piglin_Brute,
-Pillager,
-Polar_Bear,
-Ravager,
-Shulker,
-Silverfish,
-Skeleton,
-Slime,
-Sniffer,
-Spider,
-Squid,
-Stray,
-Tadpole,
-Turtle,
-Vex,
-Vindicator,
-Wandering_Trader,
-Warden,
-Witch,
-Wither,
-Wither_Skeleton,
-Zoglin,
-Zombie,
-Zombie_Pigman,
+  <summary>Click to expand the full mob list</summary>
 
-----zombie villager types----
-Zombie_Villager,
-Zombie_Armorer_Villager,
-Zombie_Butcher_Villager,
-Zombie_Cartographer_Villager,
-Zombie_Cleric_Villager,
-Zombie_Farmer_Villager,
-Zombie_Fisherman_Villager,
-Zombie_Fletcher_Villager,
-Zombie_Leatherworker_Villager,
-Zombie_Librarian_Villager,
-Zombie_Mason_Villager,
-Zombie_Nitwit_Villager,
-Zombie_Shepherd_Villager,
-Zombie_Toolsmith_Villager,
-Zombie_Weaponsmith_Villager,
+```
+Allay
+Armadillo
+Bat
+Bee
+Blaze
+Bogged
+Breeze
+Camel
+Camel_Husk
+Cave_Spider
+Creaking
+Dolphin
+Donkey
+Drowned
+Elder_Guardian
+Enderman
+Endermite
+Ender_Dragon
+Evoker
+Ghast
+Giant
+Glow_Squid
+Guardian
+Happy_Ghast
+Hoglin
+Husk
+Illusioner
+Iron_Golem
+Magma_Cube
+Mooshroom
+Mooshroom_Brown
+Mule
+Nautilus
+Ocelot
+Parched
+Phantom
+Piglin
+Piglin_Brute
+Pillager
+Polar_Bear
+Ravager
+Shulker
+Silverfish
+Skeleton
+Slime
+Sniffer
+Spider
+Squid
+Stray
+Tadpole
+Turtle
+Vex
+Vindicator
+Wandering_Trader
+Warden
+Witch
+Wither
+Wither_Skeleton
+Zoglin
+Zombie
+Zombie_Pigman
 
-----villager types----
-Villager,
-Villager_Armorer,
-Villager_Butcher,
-Villager_Cartographer,
-Villager_Cleric,
-Villager_Farmer,
-Villager_Fisherman,
-Villager_Fletcher,
-Villager_Leatherworker,
-Villager_Librarian,
-Villager_Mason,
-Villager_Nitwit,
-Villager_Shepherd,
-Villager_Toolsmith,
-Villager_Weaponsmith,
+--- Copper Golem ---
+Copper_Golem
+Exposed_Copper_Golem
+Weathered_Copper_Golem
+Oxidized_Copper_Golem
 
-----creeper types----
-Creeper,
-Charged_Creeper,
+--- Creeper ---
+Creeper
+Charged_Creeper
 
-----snow golem types----
-Snow_Golem,
-Derpy_Snow_Golem,
+--- Snow Golem ---
+Snow_Golem
+Derpy_Snow_Golem
 
-----goat types----
-Goat,
-Screaming_Goat,
+--- Goat ---
+Goat
+Screaming_Goat
 
-----strider types----
-Hot_Strider,
-Cold_Strider,
+--- Strider ---
+Hot_Strider
+Cold_Strider
 
-----axolotl types----
-Blue_Axolotl,
-Cyan_Axolotl,
-Gold_Axolotl,
-Lucy_Axolotl,
-Wild_Axolotl,
+--- Nautilus ---
+Nautilus
+Temperate_Zombie_Nautilus
+Warm_Zombie_Nautilus
 
-----cow types----
-Cow,
-Temperate_Cow,
-Cold_Cow,
-Warm_Cow,
+--- Axolotl ---
+Blue_Axolotl
+Cyan_Axolotl
+Gold_Axolotl
+Lucy_Axolotl
+Wild_Axolotl
 
-----chicken types----
-Chicken,
-Temperate_Chicken,
-Cold_Chicken,
-Warm_Chicken,
-
-----wolf types----
-Wild_Wolf,
-Tamed_Wolf,
-Tamed_Ashen_Wolf,
-Tamed_Black_Wolf,
-Tamed_Chestnut_Wolf,
-Tamed_Pale_Wolf,
-Tamed_Rusty_Wolf,
-Tamed_Snowy_Wolf,
-Tamed_Spotted_Wolf,
-Tamed_Striped_Wolf,
-Tamed_Woods_Wolf,
-Wild_Ashen_Wolf,
-Wild_Black_Wolf,
-Wild_Chestnut_Wolf,
-Wild_Pale_Wolf,
-Wild_Rusty_Wolf,
-Wild_Snowy_Wolf,
-Wild_Spotted_Wolf,
-Wild_Striped_Wolf,
-Wild_Woods_Wolf,
-
-----pig types----
-Pig,
-Temperate_Pig,
-Cold_Pig,
-Warm_Pig,
-
-----frog types----
-Frog,
-Temperate_Frog,
-Cold_Frog,
-Warm_Frog,
-
-----llama types----
-Brown_Llama,
-Creamy_Llama,
-Gray_Llama,
-White_Llama,
-Brown_Llama_Trader,
-Creamy_Llama_Trader,
-Gray_Llama_Trader,
-White_Llama_Trader,
-
-----rabbit types----
-Black_Rabbit,
-Black_and_White_Rabbit,
-Brown_Rabbit,
-Gold_Rabbit,
-Salt_and_Pepper_Rabbit,
-The_Killer_Bunny,
-Toast_Rabbit,
-White_Rabbit,
-
-----fish types----
-Tropical_Fish,
-Cod,
-Salmon,
-Pufferfish,
-
-----parrot types----
-Blue_Parrot,
-Cyan_Parrot,
-Gray_Parrot,
-Green_Parrot,
-Red_Parrot,
-
-----horse types----
-Black_Horse,
-Brown_Horse,
-Chestnut_Horse,
-Creamy_Horse,
-Dark_Brown_Horse,
-Gray_Horse,
-White_Horse,
-Skeleton_Horse,
-Zombie_Horse,
-
-----sheep types----
-Black_Sheep,
-Blue_Sheep,
-Brown_Sheep,
-Cyan_Sheep,
-Gray_Sheep,
-Green_Sheep,
-Light_Blue_Sheep,
-Lime_Sheep,
-Magenta_Sheep,
-Orange_Sheep,
-Pink_Sheep,
-Purple_Sheep,
-Rainbow_Sheep,
-Red_Sheep,
-Light_Gray_Sheep,
-White_Sheep,
-Yellow_Sheep,
-
-----panda types----
-Panda_Normal,
-Panda_Aggressive,
-Panda_Lazy,
-Panda_Brown,
-Panda_Worried,
-Panda_Playful,
-Panda_Weak,
-
-----fox types----
-Fox_Normal,
-Fox_Snow,
-
-----copper golem types----
-Copper_Golem,
-Exposed_Copper_Golem,
-Oxidized_Copper_Golem,
-Weathered_Copper_Golem,
-
-----cat types----
-Cat_AllBack,
-Cat_Black,
-Cat_British_ShortHair,
-Cat_Calico,
-Cat_Jellie,
-Cat_Persian,
-Cat_Ragdoll,
-Cat_Red,
-Cat_Siamese,
-Cat_Tabby,
+--- Cat ---
+Cat_AllBack
+Cat_Black
+Cat_British_ShortHair
+Cat_Calico
+Cat_Jellie
+Cat_Persian
+Cat_Ragdoll
+Cat_Red
+Cat_Siamese
+Cat_Tabby
 Cat_White
-  ```
+
+--- Chicken ---
+Chicken
+Temperate_Chicken
+Cold_Chicken
+Warm_Chicken
+
+--- Cow ---
+Cow
+Temperate_Cow
+Cold_Cow
+Warm_Cow
+
+--- Fox ---
+Fox_Normal
+Fox_Snow
+
+--- Frog ---
+Frog
+Temperate_Frog
+Cold_Frog
+Warm_Frog
+
+--- Horse ---
+Black_Horse
+Brown_Horse
+Chestnut_Horse
+Creamy_Horse
+Dark_Brown_Horse
+Gray_Horse
+White_Horse
+Skeleton_Horse
+Zombie_Horse
+
+--- Llama ---
+Brown_Llama
+Creamy_Llama
+Gray_Llama
+White_Llama
+Brown_Llama_Trader
+Creamy_Llama_Trader
+Gray_Llama_Trader
+White_Llama_Trader
+
+--- Panda ---
+Panda_Normal
+Panda_Aggressive
+Panda_Lazy
+Panda_Brown
+Panda_Worried
+Panda_Playful
+Panda_Weak
+
+--- Pig ---
+Pig
+Temperate_Pig
+Cold_Pig
+Warm_Pig
+
+--- Rabbit ---
+Black_Rabbit
+Black_and_White_Rabbit
+Brown_Rabbit
+Gold_Rabbit
+Salt_and_Pepper_Rabbit
+The_Killer_Bunny
+Toast_Rabbit
+White_Rabbit
+
+--- Sheep ---
+Black_Sheep
+Blue_Sheep
+Brown_Sheep
+Cyan_Sheep
+Gray_Sheep
+Green_Sheep
+Light_Blue_Sheep
+Lime_Sheep
+Magenta_Sheep
+Orange_Sheep
+Pink_Sheep
+Purple_Sheep
+Rainbow_Sheep
+Red_Sheep
+Light_Gray_Sheep
+White_Sheep
+Yellow_Sheep
+
+--- Villager ---
+Villager
+Villager_Armorer
+Villager_Butcher
+Villager_Cartographer
+Villager_Cleric
+Villager_Farmer
+Villager_Fisherman
+Villager_Fletcher
+Villager_Leatherworker
+Villager_Librarian
+Villager_Mason
+Villager_Nitwit
+Villager_Shepherd
+Villager_Toolsmith
+Villager_Weaponsmith
+
+--- Zombie Villager ---
+Zombie_Villager
+Zombie_Armorer_Villager
+Zombie_Butcher_Villager
+Zombie_Cartographer_Villager
+Zombie_Cleric_Villager
+Zombie_Farmer_Villager
+Zombie_Fisherman_Villager
+Zombie_Fletcher_Villager
+Zombie_Leatherworker_Villager
+Zombie_Librarian_Villager
+Zombie_Mason_Villager
+Zombie_Nitwit_Villager
+Zombie_Shepherd_Villager
+Zombie_Toolsmith_Villager
+Zombie_Weaponsmith_Villager
+
+--- Wolf ---
+Wild_Wolf
+Tamed_Wolf
+Wild_Ashen_Wolf
+Wild_Black_Wolf
+Wild_Chestnut_Wolf
+Wild_Pale_Wolf
+Wild_Rusty_Wolf
+Wild_Snowy_Wolf
+Wild_Spotted_Wolf
+Wild_Striped_Wolf
+Wild_Woods_Wolf
+Tamed_Ashen_Wolf
+Tamed_Black_Wolf
+Tamed_Chestnut_Wolf
+Tamed_Pale_Wolf
+Tamed_Rusty_Wolf
+Tamed_Snowy_Wolf
+Tamed_Spotted_Wolf
+Tamed_Striped_Wolf
+Tamed_Woods_Wolf
+
+--- Parrot ---
+Blue_Parrot
+Cyan_Parrot
+Gray_Parrot
+Green_Parrot
+Red_Parrot
+
+--- Fish (fishing drops) ---
+Tropical_Fish
+Cod
+Salmon
+Pufferfish
+```
+
 </details>
+
+---
+
+## Credits
+
+- [CyberDrain](https://www.spigotmc.org/resources/ultimate-mob-heads-fork.70019/) — original plugin
+- fahlur — intermediate fork
+- Lord-Lofi — this fork (Paper 1.21.11 support, new mobs, advancement system, variant-aware drops)

--- a/config.yml
+++ b/config.yml
@@ -2523,6 +2523,59 @@ ListOfMobs:
           - "mobheads:thelegend27 invulnerable_wither_2"
           - "mobheads:wither invulnerable_wither_2"
 
+  Copper_Golem:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eCopper Golem Head"
+    random_uuid: d23f3607-25a0-4c22-860a-0ucgb9a16412
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTllMjRlOTRkYmU0MmUyMzBkODMyOTNhNzdkNjFmZjcxMDFhOGM2OGFiNjhiYmM2YTkzZjk2MzBmYjJmZGI0In19fQ==
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 copper_golem"
+      - "mobheads:golem copper_golem"
+      - "mobheads:copperage copper_golem"
+  Exposed_Copper_Golem:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eExposed Copper Golem Head"
+    random_uuid: d23f3607-25a0-4c22-860a-0ecgb9a16412
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOGE5ZTQxMGM4YjdmZGJkNGI5ZDhlYTgwNzViYzY2YTljMWFkYTliYzE1ODczYjRiMWRlYWRhYTI4MTJiODQ3ZCJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 exposed_copper_golem"
+      - "mobheads:golem copper_golem"
+      - "mobheads:copperage exposed_copper_golem"
+  Weathered_Copper_Golem:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eWeathered Copper Golem Head"
+    random_uuid: d23f3607-25a0-4c22-860a-0wcgb9a16412
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODI2Mjk5MmQ2ZDVhNjJhMWRkM2VkZThlNGMzNGYxYzE4MDUwYmFiNjQyNzFkOTI2YzFjMGM2MTYyYjJjZDc0ZSJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 weathered_copper_golem"
+      - "mobheads:golem copper_golem"
+      - "mobheads:copperage weathered_copper_golem"
+  Oxidized_Copper_Golem:
+    dropChance: DEFAULT
+    lootingBonus: DEFAULT
+    dropOnChargedCreeperDeath: true
+    broadcastMessage: true
+    displayName: "&eOxidized Copper Golem Head"
+    random_uuid: d23f3607-25a0-4c22-860a-0ocgb9a16412
+    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2MyYWFiOGEwZmVjM2NjMDZhNGQ0NzQ4MGUwMjRmODhmMmIwN2JjOTZlZTA5ZTUzMzFlNWY0ZGI2YjI3Mzg4NSJ9fX0=
+    advancements:
+      - "mobheads:firstmobhead first_mob_head"
+      - "mobheads:thelegend27 oxidized_copper_golem"
+      - "mobheads:golem copper_golem"
+      - "mobheads:copperage oxidized_copper_golem"
+
 
 #List of all fish that are supported in this plugin.
 #You can obtain these fish by fishing. When you catch a fish, there is a chance (dropChance) that the player will also catch the corresponding fish head.
@@ -2577,59 +2630,6 @@ ListOfFish:
       - "mobheads:thelegend27 pufferfish"
       - "mobheads:fish pufferfish"
       - "mobheads:watermobs pufferfish"
-
-  Copper_Golem:
-    dropChance: DEFAULT
-    lootingBonus: DEFAULT
-    dropOnChargedCreeperDeath: true
-    broadcastMessage: true
-    displayName: "&eCopper Golem Head"
-    random_uuid: d23f3607-25a0-4c22-860a-0ucgb9a16412
-    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTllMjRlOTRkYmU0MmUyMzBkODMyOTNhNzdkNjFmZjcxMDFhOGM2OGFiNjhiYmM2YTkzZjk2MzBmYjJmZGI0In19fQ==
-    advancements:
-      - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 copper_golem"
-      - "mobheads:golem copper_golem"
-      - "mobheads:copperage copper_golem"
-  Exposed_Copper_Golem:
-    dropChance: DEFAULT
-    lootingBonus: DEFAULT
-    dropOnChargedCreeperDeath: true
-    broadcastMessage: true
-    displayName: "&eExposed Copper Golem Head"
-    random_uuid: d23f3607-25a0-4c22-860a-0ecgb9a16412
-    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOGE5ZTQxMGM4YjdmZGJkNGI5ZDhlYTgwNzViYzY2YTljMWFkYTliYzE1ODczYjRiMWRlYWRhYTI4MTJiODQ3ZCJ9fX0=
-    advancements:
-      - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 exposed_copper_golem"
-      - "mobheads:golem copper_golem"
-      - "mobheads:copperage exposed_copper_golem"
-  Weathered_Copper_Golem:
-    dropChance: DEFAULT
-    lootingBonus: DEFAULT
-    dropOnChargedCreeperDeath: true
-    broadcastMessage: true
-    displayName: "&eWeathered Copper Golem Head"
-    random_uuid: d23f3607-25a0-4c22-860a-0wcgb9a16412
-    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODI2Mjk5MmQ2ZDVhNjJhMWRkM2VkZThlNGMzNGYxYzE4MDUwYmFiNjQyNzFkOTI2YzFjMGM2MTYyYjJjZDc0ZSJ9fX0=
-    advancements:
-      - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 weathered_copper_golem"
-      - "mobheads:golem copper_golem"
-      - "mobheads:copperage weathered_copper_golem"
-  Oxidized_Copper_Golem:
-    dropChance: DEFAULT
-    lootingBonus: DEFAULT
-    dropOnChargedCreeperDeath: true
-    broadcastMessage: true
-    displayName: "&eOxidized Copper Golem Head"
-    random_uuid: d23f3607-25a0-4c22-860a-0ocgb9a16412
-    textureCode: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2MyYWFiOGEwZmVjM2NjMDZhNGQ0NzQ4MGUwMjRmODhmMmIwN2JjOTZlZTA5ZTUzMzFlNWY0ZGI2YjI3Mzg4NSJ9fX0=
-    advancements:
-      - "mobheads:firstmobhead first_mob_head"
-      - "mobheads:thelegend27 oxidized_copper_golem"
-      - "mobheads:golem copper_golem"
-      - "mobheads:copperage oxidized_copper_golem"
 
 #Whenever a player dies by another player
 Player:

--- a/src/com/cyber/mobheads/Utilities/MobNames.java
+++ b/src/com/cyber/mobheads/Utilities/MobNames.java
@@ -1,5 +1,6 @@
 package com.cyber.mobheads.Utilities;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.*;
 import org.bukkit.entity.Villager.Profession;
@@ -664,9 +665,11 @@ public enum MobNames {
 	}
 
 	private static MobNames getCopperGolemName(Entity entity) {
+		Bukkit.getLogger().info("[MobHeads DEBUG] getCopperGolemName called, entity class: " + entity.getClass().getName());
 		try {
 			// Paper API: getWeatheringState()
 			Object state = entity.getClass().getMethod("getWeatheringState").invoke(entity);
+			Bukkit.getLogger().info("[MobHeads DEBUG] getWeatheringState() returned: " + state);
 			switch (state.toString()) {
 				case "EXPOSED":   return Exposed_Copper_Golem;
 				case "WEATHERED": return Weathered_Copper_Golem;
@@ -674,9 +677,11 @@ public enum MobNames {
 				default:          return Copper_Golem;
 			}
 		} catch (NoSuchMethodException e) {
+			Bukkit.getLogger().info("[MobHeads DEBUG] getWeatheringState() not found, trying getWeatherState()");
 			try {
 				// Spigot API fallback: getWeatherState()
 				Object state = entity.getClass().getMethod("getWeatherState").invoke(entity);
+				Bukkit.getLogger().info("[MobHeads DEBUG] getWeatherState() returned: " + state);
 				switch (state.toString()) {
 					case "EXPOSED":   return Exposed_Copper_Golem;
 					case "WEATHERED": return Weathered_Copper_Golem;
@@ -684,9 +689,11 @@ public enum MobNames {
 					default:          return Copper_Golem;
 				}
 			} catch (Exception ex) {
+				Bukkit.getLogger().info("[MobHeads DEBUG] getWeatherState() also failed: " + ex.getClass().getName() + ": " + ex.getMessage());
 				return Copper_Golem;
 			}
 		} catch (Exception e) {
+			Bukkit.getLogger().info("[MobHeads DEBUG] getWeatheringState() invocation failed: " + e.getClass().getName() + ": " + e.getMessage());
 			return Copper_Golem;
 		}
 	}

--- a/src/com/cyber/mobheads/Utilities/MobNames.java
+++ b/src/com/cyber/mobheads/Utilities/MobNames.java
@@ -665,11 +665,9 @@ public enum MobNames {
 	}
 
 	private static MobNames getCopperGolemName(Entity entity) {
-		Bukkit.getLogger().info("[MobHeads DEBUG] getCopperGolemName called, entity class: " + entity.getClass().getName());
 		try {
 			// Paper API: getWeatheringState()
 			Object state = entity.getClass().getMethod("getWeatheringState").invoke(entity);
-			Bukkit.getLogger().info("[MobHeads DEBUG] getWeatheringState() returned: " + state);
 			switch (state.toString()) {
 				case "EXPOSED":   return Exposed_Copper_Golem;
 				case "WEATHERED": return Weathered_Copper_Golem;
@@ -677,11 +675,9 @@ public enum MobNames {
 				default:          return Copper_Golem;
 			}
 		} catch (NoSuchMethodException e) {
-			Bukkit.getLogger().info("[MobHeads DEBUG] getWeatheringState() not found, trying getWeatherState()");
 			try {
 				// Spigot API fallback: getWeatherState()
 				Object state = entity.getClass().getMethod("getWeatherState").invoke(entity);
-				Bukkit.getLogger().info("[MobHeads DEBUG] getWeatherState() returned: " + state);
 				switch (state.toString()) {
 					case "EXPOSED":   return Exposed_Copper_Golem;
 					case "WEATHERED": return Weathered_Copper_Golem;
@@ -689,11 +685,9 @@ public enum MobNames {
 					default:          return Copper_Golem;
 				}
 			} catch (Exception ex) {
-				Bukkit.getLogger().info("[MobHeads DEBUG] getWeatherState() also failed: " + ex.getClass().getName() + ": " + ex.getMessage());
 				return Copper_Golem;
 			}
 		} catch (Exception e) {
-			Bukkit.getLogger().info("[MobHeads DEBUG] getWeatheringState() invocation failed: " + e.getClass().getName() + ": " + e.getMessage());
 			return Copper_Golem;
 		}
 	}

--- a/src/com/cyber/mobheads/Utilities/MobNames.java
+++ b/src/com/cyber/mobheads/Utilities/MobNames.java
@@ -305,7 +305,7 @@ public enum MobNames {
 			case CHICKEN:
 				return getChickenName((Chicken) entity);
 			case COPPER_GOLEM:
-				return getCopperGolemName((CopperGolem) entity);
+				return getCopperGolemName(entity);
 			case COW:
 				return getCowName((Cow) entity);
 			case CREAKING:
@@ -663,21 +663,32 @@ public enum MobNames {
 		return Snow_Golem;
 	}
 
-	private static MobNames getCopperGolemName(CopperGolem coppergolem) {
-		if (coppergolem.getWeatherState() == null) {
-                return Copper_Golem;
-		}
-		switch (coppergolem.getWeatherState()) {
-			case EXPOSED:
-				return Exposed_Copper_Golem;
-			case OXIDIZED:
-				return Oxidized_Copper_Golem;
-			case WEATHERED:
-				return Weathered_Copper_Golem;
-			case UNAFFECTED:
+	private static MobNames getCopperGolemName(Entity entity) {
+		try {
+			// Paper API: getWeatheringState()
+			Object state = entity.getClass().getMethod("getWeatheringState").invoke(entity);
+			switch (state.toString()) {
+				case "EXPOSED":   return Exposed_Copper_Golem;
+				case "WEATHERED": return Weathered_Copper_Golem;
+				case "OXIDIZED":  return Oxidized_Copper_Golem;
+				default:          return Copper_Golem;
+			}
+		} catch (NoSuchMethodException e) {
+			try {
+				// Spigot API fallback: getWeatherState()
+				Object state = entity.getClass().getMethod("getWeatherState").invoke(entity);
+				switch (state.toString()) {
+					case "EXPOSED":   return Exposed_Copper_Golem;
+					case "WEATHERED": return Weathered_Copper_Golem;
+					case "OXIDIZED":  return Oxidized_Copper_Golem;
+					default:          return Copper_Golem;
+				}
+			} catch (Exception ex) {
 				return Copper_Golem;
+			}
+		} catch (Exception e) {
+			return Copper_Golem;
 		}
-		return Copper_Golem;
 	}
 
 	private static MobNames getHorseName(Horse horse) {

--- a/src/com/cyber/mobheads/listeners/EntityDeathListener.java
+++ b/src/com/cyber/mobheads/listeners/EntityDeathListener.java
@@ -31,13 +31,18 @@ public class EntityDeathListener
 	public void onChargedCreeperDeath(EntityDamageByEntityEvent event) {
 		if (event.getEntity() instanceof LivingEntity) {
 			LivingEntity le = (LivingEntity) event.getEntity();
-			if (le.getHealth() - event.getDamage() <= 0.0D &&
-					event.getDamager() instanceof Creeper && (
-					(Creeper) event.getDamager()).isPowered()) {
-
+			boolean willDie = le.getHealth() - event.getDamage() <= 0.0D;
+			boolean isChargedCreeper = event.getDamager() instanceof Creeper && ((Creeper) event.getDamager()).isPowered();
+			if (le.getType().name().equals("COPPER_GOLEM")) {
+				Bukkit.getLogger().info("[MobHeads DEBUG] COPPER_GOLEM damage event - health: " + le.getHealth() + ", damage: " + event.getDamage() + ", willDie: " + willDie + ", isChargedCreeper: " + isChargedCreeper + ", damager: " + event.getDamager().getType().name());
+			}
+			if (willDie && isChargedCreeper) {
 				MobNames mobName = MobNames.getName(event.getEntity());
-				if ((mobName != null && ConfigController.chargedCreeperDrop(mobName)) || (event
-						.getEntity() instanceof Player && ConfigController.chargedCreeperDropForPlayer())) {
+				boolean creeperDrop = mobName != null && ConfigController.chargedCreeperDrop(mobName);
+				if (le.getType().name().equals("COPPER_GOLEM")) {
+					Bukkit.getLogger().info("[MobHeads DEBUG] COPPER_GOLEM killing blow - mobName: " + mobName + ", creeperDrop: " + creeperDrop);
+				}
+				if (creeperDrop || (event.getEntity() instanceof Player && ConfigController.chargedCreeperDropForPlayer())) {
 					this.killedByChargedCreeper.add(event.getEntity().getUniqueId());
 				}
 			}

--- a/src/com/cyber/mobheads/listeners/EntityDeathListener.java
+++ b/src/com/cyber/mobheads/listeners/EntityDeathListener.java
@@ -31,18 +31,13 @@ public class EntityDeathListener
 	public void onChargedCreeperDeath(EntityDamageByEntityEvent event) {
 		if (event.getEntity() instanceof LivingEntity) {
 			LivingEntity le = (LivingEntity) event.getEntity();
-			boolean willDie = le.getHealth() - event.getDamage() <= 0.0D;
-			boolean isChargedCreeper = event.getDamager() instanceof Creeper && ((Creeper) event.getDamager()).isPowered();
-			if (le.getType().name().equals("COPPER_GOLEM")) {
-				Bukkit.getLogger().info("[MobHeads DEBUG] COPPER_GOLEM damage event - health: " + le.getHealth() + ", damage: " + event.getDamage() + ", willDie: " + willDie + ", isChargedCreeper: " + isChargedCreeper + ", damager: " + event.getDamager().getType().name());
-			}
-			if (willDie && isChargedCreeper) {
+			if (le.getHealth() - event.getDamage() <= 0.0D &&
+					event.getDamager() instanceof Creeper && (
+					(Creeper) event.getDamager()).isPowered()) {
+
 				MobNames mobName = MobNames.getName(event.getEntity());
-				boolean creeperDrop = mobName != null && ConfigController.chargedCreeperDrop(mobName);
-				if (le.getType().name().equals("COPPER_GOLEM")) {
-					Bukkit.getLogger().info("[MobHeads DEBUG] COPPER_GOLEM killing blow - mobName: " + mobName + ", creeperDrop: " + creeperDrop);
-				}
-				if (creeperDrop || (event.getEntity() instanceof Player && ConfigController.chargedCreeperDropForPlayer())) {
+				if ((mobName != null && ConfigController.chargedCreeperDrop(mobName)) || (event
+						.getEntity() instanceof Player && ConfigController.chargedCreeperDropForPlayer())) {
 					this.killedByChargedCreeper.add(event.getEntity().getUniqueId());
 				}
 			}

--- a/src/com/cyber/mobheads/listeners/EntityDeathListener.java
+++ b/src/com/cyber/mobheads/listeners/EntityDeathListener.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import java.util.logging.Logger;
 
 public class EntityDeathListener
 		implements Listener {
@@ -66,12 +67,14 @@ public class EntityDeathListener
 
 
 		if (this.killedByChargedCreeper.remove(livingEntity.getUniqueId())) {
+			Bukkit.getLogger().info("[MobHeads DEBUG] Charged creeper drop triggered for: " + livingEntity.getType().name());
 			ItemStack skull;
 			if (livingEntity instanceof Player) {
 				skull = getPlayerHead((Player) livingEntity, null, true);
 			} else {
 				skull = getMobHead(null, livingEntity, true);
 			}
+			Bukkit.getLogger().info("[MobHeads DEBUG] skull is: " + (skull == null ? "NULL" : skull.getType().name()));
 
 			boolean alreadyThere = false;
 			for (ItemStack is : event.getDrops()) {


### PR DESCRIPTION
Summary

This patch brings full Paper 1.21.11 compatibility, adds five new 1.21.11 mobs, and fixes a critical runtime crash affecting all mob head drops.

Changes

Critical fix: Resolved NoClassDefFoundError crashing all mob head drops on Paper 1.21.11. Root cause was a Spigot/Paper API mismatch on CopperGolem — Paper uses getWeatheringState() returning io.papermc.paper.world.WeatheringCopperState instead of Spigot's getWeatherState(). Fixed using reflection to support both APIs at runtime with a graceful fallback.

Config fix: Copper Golem variants (Copper_Golem, Exposed_Copper_Golem, Weathered_Copper_Golem, Oxidized_Copper_Golem) were accidentally placed under ListOfFish instead of ListOfMobs, preventing charged creeper detection and mob meta lookups from finding them. Moved to correct section.

New mobs (1.21.11): Added Camel_Husk, Parched, Nautilus, Temperate_Zombie_Nautilus, and Warm_Zombie_Nautilus — including MobNames enum entries, entity type switch cases, config entries with textures, and advancement references.

Snow Golem: Updated Snow_Golem texture to a carved pumpkin skin. Derpy_Snow_Golem uses the exposed face skin.

README: Rewrote with full project description, features, requirements, installation, permissions, config reference, and complete mob list.